### PR TITLE
feat: add multi-interface monitoring and BPF filter (#15, #2)

### DIFF
--- a/pkt_monitor.c
+++ b/pkt_monitor.c
@@ -39,9 +39,12 @@
 #define TIMEOUT_SEC  1
 #define TIMEOUT_USEC 0
 
-static packet_counter_t pkt_cnt;
-static packet_counter_t total_cnt;
-static pcap_t *handle;
+/* ---- global state ----------------------------------------------------- */
+
+static iface_ctx_t ifaces[MAX_IFACES];
+static int iface_count;
+static char *filter_expr;
+static volatile sig_atomic_t running = 1;
 
 /*
  * Get current time as HH:MM:SS string.
@@ -57,6 +60,24 @@ static void get_time(char *buf, size_t len)
 }
 
 /*
+ * Accumulate per-second counters into totals for one interface.
+ */
+static void accumulate_totals(iface_ctx_t *ctx)
+{
+    ctx->total_cnt.all  += ctx->pkt_cnt.all;
+    ctx->total_cnt.ip   += ctx->pkt_cnt.ip;
+    ctx->total_cnt.ipv6 += ctx->pkt_cnt.ipv6;
+    ctx->total_cnt.arp  += ctx->pkt_cnt.arp;
+    ctx->total_cnt.icmp += ctx->pkt_cnt.icmp;
+    ctx->total_cnt.tcp  += ctx->pkt_cnt.tcp;
+    ctx->total_cnt.udp  += ctx->pkt_cnt.udp;
+    ctx->total_cnt.bps  += ctx->pkt_cnt.bps;
+    ctx->elapsed_sec++;
+
+    memset(&ctx->pkt_cnt, 0, sizeof(ctx->pkt_cnt));
+}
+
+/*
  * SIGALRM handler: print stats every second, header every INTVAL seconds.
  * Used only in text mode.
  */
@@ -64,24 +85,39 @@ static void alarm_handler(int sig)
 {
     char timebuf[16];
     static int sec = 1;
+    int i;
 
     (void)sig;
 
     get_time(timebuf, sizeof(timebuf));
 
     if ((sec % INTVAL) == 1) {
-        printf("# time #\t  all\t ipv4\t ipv6\tarp\ticmp\ttcp\tudp\n");
+        if (iface_count > 1)
+            printf("# time #\tiface\t  all\t ipv4\t ipv6\tarp\ticmp"
+                   "\ttcp\tudp\n");
+        else
+            printf("# time #\t  all\t ipv4\t ipv6\tarp\ticmp\ttcp\tudp\n");
         sec = 1;
     }
 
-    printf("%s\t%5d\t%5d\t%5d\t%3d\t%3d\t%5d\t%5d%6.1fkbps\n",
-           timebuf, pkt_cnt.all, pkt_cnt.ip,
-           pkt_cnt.ipv6, pkt_cnt.arp, pkt_cnt.icmp,
-           pkt_cnt.tcp, pkt_cnt.udp, (double)pkt_cnt.bps * 8 / 1024);
+    for (i = 0; i < iface_count; i++) {
+        packet_counter_t *c = &ifaces[i].pkt_cnt;
+        if (iface_count > 1)
+            printf("%s\t%s\t%5d\t%5d\t%5d\t%3d\t%3d\t%5d\t%5d%6.1fkbps\n",
+                   timebuf, ifaces[i].name,
+                   c->all, c->ip, c->ipv6, c->arp, c->icmp,
+                   c->tcp, c->udp, (double)c->bps * 8 / 1024);
+        else
+            printf("%s\t%5d\t%5d\t%5d\t%3d\t%3d\t%5d\t%5d%6.1fkbps\n",
+                   timebuf,
+                   c->all, c->ip, c->ipv6, c->arp, c->icmp,
+                   c->tcp, c->udp, (double)c->bps * 8 / 1024);
+    }
 
     sec++;
 
-    memset(&pkt_cnt, 0, sizeof(pkt_cnt));
+    for (i = 0; i < iface_count; i++)
+        accumulate_totals(&ifaces[i]);
 }
 
 /*
@@ -103,34 +139,34 @@ static void setup_timer(void)
 
 /*
  * pcap callback: parse each captured packet and update counters.
+ * The user pointer points to the iface_ctx_t's pkt_cnt.
  */
 static void packet_handler(u_char *user, const struct pcap_pkthdr *header,
                            const u_char *packet)
 {
+    packet_counter_t *cnt = (packet_counter_t *)user;
     const struct ether_header *eth;
     const struct ip *iph;
     uint16_t ether_type;
 
-    (void)user;
-
     if (header->caplen < sizeof(struct ether_header))
         return;
 
-    pkt_cnt.all++;
-    pkt_cnt.bps += header->len;
+    cnt->all++;
+    cnt->bps += header->len;
 
     eth = (const struct ether_header *)packet;
     ether_type = ntohs(eth->ether_type);
 
     switch (ether_type) {
     case ETHERTYPE_IP:
-        pkt_cnt.ip++;
+        cnt->ip++;
         break;
     case ETHERTYPE_IPV6:
-        pkt_cnt.ipv6++;
+        cnt->ipv6++;
         return;
     case ETHERTYPE_ARP:
-        pkt_cnt.arp++;
+        cnt->arp++;
         return;
     default:
         return;
@@ -144,30 +180,15 @@ static void packet_handler(u_char *user, const struct pcap_pkthdr *header,
 
     switch (iph->ip_p) {
     case IPPROTO_ICMP:
-        pkt_cnt.icmp++;
+        cnt->icmp++;
         break;
     case IPPROTO_TCP:
-        pkt_cnt.tcp++;
+        cnt->tcp++;
         break;
     case IPPROTO_UDP:
-        pkt_cnt.udp++;
+        cnt->udp++;
         break;
     }
-}
-
-/*
- * Accumulate per-second counters into totals.
- */
-static void accumulate_totals(void)
-{
-    total_cnt.all  += pkt_cnt.all;
-    total_cnt.ip   += pkt_cnt.ip;
-    total_cnt.ipv6 += pkt_cnt.ipv6;
-    total_cnt.arp  += pkt_cnt.arp;
-    total_cnt.icmp += pkt_cnt.icmp;
-    total_cnt.tcp  += pkt_cnt.tcp;
-    total_cnt.udp  += pkt_cnt.udp;
-    total_cnt.bps  += pkt_cnt.bps;
 }
 
 /*
@@ -175,11 +196,50 @@ static void accumulate_totals(void)
  */
 static void cleanup_handler(int sig)
 {
+    int i;
     (void)sig;
 
-    if (handle) {
-        pcap_breakloop(handle);
+    running = 0;
+    for (i = 0; i < iface_count; i++)
+        if (ifaces[i].handle)
+            pcap_breakloop(ifaces[i].handle);
+}
+
+/*
+ * Close all pcap handles.
+ */
+static void cleanup_all(void)
+{
+    int i;
+    for (i = 0; i < iface_count; i++) {
+        if (ifaces[i].handle) {
+            pcap_close(ifaces[i].handle);
+            ifaces[i].handle = NULL;
+        }
     }
+}
+
+/*
+ * Apply BPF filter to a pcap handle.
+ * Returns 0 on success, -1 on error.
+ */
+static int apply_filter(pcap_t *h, const char *iface_name, const char *expr)
+{
+    struct bpf_program fp;
+
+    if (pcap_compile(h, &fp, expr, 1, PCAP_NETMASK_UNKNOWN) == -1) {
+        fprintf(stderr, "Filter compile error on %s: %s\n",
+                iface_name, pcap_geterr(h));
+        return -1;
+    }
+    if (pcap_setfilter(h, &fp) == -1) {
+        fprintf(stderr, "Filter set error on %s: %s\n",
+                iface_name, pcap_geterr(h));
+        pcap_freecode(&fp);
+        return -1;
+    }
+    pcap_freecode(&fp);
+    return 0;
 }
 
 /*
@@ -194,16 +254,15 @@ static long long now_ms(void)
 
 #ifdef HAS_NCURSES
 /*
- * TUI mode main loop using pcap_dispatch (non-blocking).
+ * TUI mode main loop using round-robin pcap_dispatch (non-blocking).
  */
-static int run_tui(const char *device, const char *dir_str)
+static int run_tui(const char *dir_str)
 {
-    int elapsed = 0;
     int paused = 0;
     long long last_tick;
-    int action;
+    int action, i;
 
-    if (tui_init(device, dir_str) < 0)
+    if (tui_init(ifaces, iface_count, dir_str) < 0)
         return 1;
 
     /* Disable SIGALRM in TUI mode */
@@ -212,27 +271,29 @@ static int run_tui(const char *device, const char *dir_str)
     signal(SIGINT,  cleanup_handler);
     signal(SIGTERM, cleanup_handler);
 
-    memset(&pkt_cnt, 0, sizeof(pkt_cnt));
-    memset(&total_cnt, 0, sizeof(total_cnt));
-
     /* Initial draw */
-    tui_update(&pkt_cnt, &total_cnt, elapsed, paused);
+    tui_update(ifaces, iface_count, paused);
 
     last_tick = now_ms();
 
     for (;;) {
-        /* Process packets (non-blocking, pcap timeout handles ~100ms) */
-        if (pcap_dispatch(handle, -1, packet_handler, NULL) == PCAP_ERROR_BREAK)
-            break;
+        /* Round-robin dispatch across all interfaces */
+        for (i = 0; i < iface_count; i++) {
+            int ret = pcap_dispatch(ifaces[i].handle, -1, packet_handler,
+                                    (u_char *)&ifaces[i].pkt_cnt);
+            if (ret == PCAP_ERROR_BREAK) {
+                tui_cleanup();
+                return 0;
+            }
+        }
 
         /* Check for 1-second tick */
         if (now_ms() - last_tick >= 1000) {
             last_tick += 1000;
             if (!paused) {
-                elapsed++;
-                accumulate_totals();
-                tui_update(&pkt_cnt, &total_cnt, elapsed, paused);
-                memset(&pkt_cnt, 0, sizeof(pkt_cnt));
+                for (i = 0; i < iface_count; i++)
+                    accumulate_totals(&ifaces[i]);
+                tui_update(ifaces, iface_count, paused);
             }
         }
 
@@ -243,10 +304,12 @@ static int run_tui(const char *device, const char *dir_str)
         if (action == 'p')
             paused = !paused;
         if (action == 'r') {
-            memset(&pkt_cnt, 0, sizeof(pkt_cnt));
-            memset(&total_cnt, 0, sizeof(total_cnt));
-            elapsed = 0;
-            tui_update(&pkt_cnt, &total_cnt, elapsed, paused);
+            for (i = 0; i < iface_count; i++) {
+                memset(&ifaces[i].pkt_cnt, 0, sizeof(packet_counter_t));
+                memset(&ifaces[i].total_cnt, 0, sizeof(packet_counter_t));
+                ifaces[i].elapsed_sec = 0;
+            }
+            tui_update(ifaces, iface_count, paused);
         }
     }
 
@@ -260,14 +323,23 @@ int main(int argc, char *argv[])
     char errbuf[PCAP_ERRBUF_SIZE];
     int direction = 0; /* 0=both, 1=in, 2=out */
     int use_tui = 0;
-    int opt;
-    const char *device = NULL;
+    int opt, i;
     const char *dir_str;
+    int timeout_ms;
 
-    while ((opt = getopt(argc, argv, "d:iouh")) != -1) {
+    while ((opt = getopt(argc, argv, "d:f:iouh")) != -1) {
         switch (opt) {
         case 'd':
-            device = optarg;
+            if (iface_count >= MAX_IFACES) {
+                fprintf(stderr, "Error: max %d interfaces\n", MAX_IFACES);
+                return 1;
+            }
+            snprintf(ifaces[iface_count].name,
+                     sizeof(ifaces[iface_count].name), "%s", optarg);
+            iface_count++;
+            break;
+        case 'f':
+            filter_expr = optarg;
             break;
         case 'i':
             direction = 1;
@@ -281,8 +353,10 @@ int main(int argc, char *argv[])
         case 'h':
         default:
             fprintf(stderr,
-                    "Usage: %s [-d device] [-i|-o] [-u] [-h]\n"
-                    "  -d device   Network interface (default: auto-detect)\n"
+                    "Usage: %s [-d device [-d device2 ...]] [-f filter]"
+                    " [-i|-o] [-u] [-h]\n"
+                    "  -d device   Network interface (repeatable, max %d)\n"
+                    "  -f filter   BPF filter expression (tcpdump syntax)\n"
                     "  -i          Capture incoming packets only\n"
                     "  -o          Capture outgoing packets only\n"
 #ifdef HAS_NCURSES
@@ -291,27 +365,30 @@ int main(int argc, char *argv[])
                     "  -u          TUI mode (not available, build with ncurses)\n"
 #endif
                     "  -h          Show this help\n",
-                    argv[0]);
+                    argv[0], MAX_IFACES);
             return (opt == 'h') ? 0 : 1;
         }
     }
 
     /* Legacy positional argument support: pkt_monitor <device> */
-    if (!device && optind < argc) {
-        device = argv[optind];
+    if (iface_count == 0 && optind < argc) {
+        snprintf(ifaces[0].name, sizeof(ifaces[0].name), "%s", argv[optind]);
+        iface_count = 1;
     }
 
     /* Auto-detect device if not specified */
-    if (!device) {
+    if (iface_count == 0) {
         pcap_if_t *alldevs;
 
         if (pcap_findalldevs(&alldevs, errbuf) == -1 || alldevs == NULL) {
             fprintf(stderr, "No capture device found: %s\n", errbuf);
             return 1;
         }
-        device = alldevs->name;
+        snprintf(ifaces[0].name, sizeof(ifaces[0].name), "%s", alldevs->name);
+        iface_count = 1;
+        pcap_freealldevs(alldevs);
         if (!use_tui)
-            printf("# auto-detected device: %s\n", device);
+            printf("# auto-detected device: %s\n", ifaces[0].name);
     }
 
     /* TUI requires ncurses */
@@ -323,32 +400,52 @@ int main(int argc, char *argv[])
 #endif
 
     /*
-     * Open capture device.
-     * promiscuous mode = 1, timeout = 100ms
+     * Open all capture devices.
+     * Adjust timeout per interface for fair round-robin.
      */
-    handle = pcap_open_live(device, SNAP_LEN, 1, 100, errbuf);
-    if (!handle) {
-        fprintf(stderr, "pcap_open_live(%s): %s\n", device, errbuf);
-        return 1;
-    }
+    timeout_ms = 100 / iface_count;
+    if (timeout_ms < 10) timeout_ms = 10;
 
-    /* Verify Ethernet link layer */
-    if (pcap_datalink(handle) != DLT_EN10MB) {
-        fprintf(stderr, "Device %s does not provide Ethernet headers\n", device);
-        pcap_close(handle);
-        return 1;
-    }
+    for (i = 0; i < iface_count; i++) {
+        memset(&ifaces[i].pkt_cnt, 0, sizeof(packet_counter_t));
+        memset(&ifaces[i].total_cnt, 0, sizeof(packet_counter_t));
+        ifaces[i].elapsed_sec = 0;
 
-    /* Set capture direction if requested */
-    if (direction == 1) {
-        if (pcap_setdirection(handle, PCAP_D_IN) == -1) {
-            fprintf(stderr, "Warning: cannot set direction to inbound: %s\n",
-                    pcap_geterr(handle));
+        ifaces[i].handle = pcap_open_live(ifaces[i].name, SNAP_LEN, 1,
+                                          timeout_ms, errbuf);
+        if (!ifaces[i].handle) {
+            fprintf(stderr, "pcap_open_live(%s): %s\n",
+                    ifaces[i].name, errbuf);
+            cleanup_all();
+            return 1;
         }
-    } else if (direction == 2) {
-        if (pcap_setdirection(handle, PCAP_D_OUT) == -1) {
-            fprintf(stderr, "Warning: cannot set direction to outbound: %s\n",
-                    pcap_geterr(handle));
+
+        /* Verify Ethernet link layer */
+        if (pcap_datalink(ifaces[i].handle) != DLT_EN10MB) {
+            fprintf(stderr, "Device %s does not provide Ethernet headers\n",
+                    ifaces[i].name);
+            cleanup_all();
+            return 1;
+        }
+
+        /* Set capture direction if requested */
+        if (direction == 1) {
+            if (pcap_setdirection(ifaces[i].handle, PCAP_D_IN) == -1)
+                fprintf(stderr, "Warning: %s: cannot set direction to inbound: %s\n",
+                        ifaces[i].name, pcap_geterr(ifaces[i].handle));
+        } else if (direction == 2) {
+            if (pcap_setdirection(ifaces[i].handle, PCAP_D_OUT) == -1)
+                fprintf(stderr, "Warning: %s: cannot set direction to outbound: %s\n",
+                        ifaces[i].name, pcap_geterr(ifaces[i].handle));
+        }
+
+        /* Apply BPF filter */
+        if (filter_expr) {
+            if (apply_filter(ifaces[i].handle, ifaces[i].name,
+                             filter_expr) == -1) {
+                cleanup_all();
+                return 1;
+            }
         }
     }
 
@@ -356,24 +453,46 @@ int main(int argc, char *argv[])
 
 #ifdef HAS_NCURSES
     if (use_tui) {
-        int ret = run_tui(device, dir_str);
-        pcap_close(handle);
+        int ret = run_tui(dir_str);
+        cleanup_all();
         return ret;
     }
 #endif
 
     /* Text mode */
-    printf("# Capturing on %s (direction: %s)\n", device, dir_str);
+    if (iface_count == 1) {
+        printf("# Capturing on %s (direction: %s)", ifaces[0].name, dir_str);
+    } else {
+        printf("# Capturing on");
+        for (i = 0; i < iface_count; i++)
+            printf(" %s%s", ifaces[i].name,
+                   i < iface_count - 1 ? "," : "");
+        printf(" (direction: %s)", dir_str);
+    }
+    if (filter_expr)
+        printf(" [filter: %s]", filter_expr);
+    printf("\n");
 
     setup_timer();
 
     signal(SIGINT,  cleanup_handler);
     signal(SIGTERM, cleanup_handler);
 
-    memset(&pkt_cnt, 0, sizeof(pkt_cnt));
-    pcap_loop(handle, -1, packet_handler, NULL);
+    /* Round-robin dispatch */
+    while (running) {
+        for (i = 0; i < iface_count; i++) {
+            int ret = pcap_dispatch(ifaces[i].handle, -1, packet_handler,
+                                    (u_char *)&ifaces[i].pkt_cnt);
+            if (ret == PCAP_ERROR) {
+                fprintf(stderr, "pcap error on %s: %s\n",
+                        ifaces[i].name, pcap_geterr(ifaces[i].handle));
+                running = 0;
+                break;
+            }
+        }
+    }
 
-    pcap_close(handle);
+    cleanup_all();
     printf("\n# Capture stopped.\n");
 
     return 0;

--- a/pkt_monitor.h
+++ b/pkt_monitor.h
@@ -5,8 +5,11 @@
 #ifndef PKT_MONITOR_H
 #define PKT_MONITOR_H
 
+#include <pcap/pcap.h>
+
 #define SNAP_LEN     1600
 #define INTVAL       10
+#define MAX_IFACES   8
 
 typedef struct {
     int all;
@@ -18,5 +21,13 @@ typedef struct {
     int udp;
     int bps;
 } packet_counter_t;
+
+typedef struct {
+    char             name[16];
+    pcap_t          *handle;
+    packet_counter_t pkt_cnt;     /* per-second, reset every tick */
+    packet_counter_t total_cnt;   /* cumulative */
+    int              elapsed_sec;
+} iface_ctx_t;
 
 #endif /* PKT_MONITOR_H */

--- a/tui.c
+++ b/tui.c
@@ -13,7 +13,8 @@
 #define MIN_HEIGHT 15
 #define BAR_MAX    20
 
-static const char *tui_device;
+static iface_ctx_t *tui_ifaces;
+static int tui_iface_count;
 static const char *tui_direction;
 static volatile sig_atomic_t needs_resize = 0;
 
@@ -23,7 +24,7 @@ static void sigwinch_handler(int sig)
     needs_resize = 1;
 }
 
-int tui_init(const char *device, const char *direction)
+int tui_init(iface_ctx_t *ifaces, int iface_count, const char *direction)
 {
     initscr();
     if (has_colors()) {
@@ -41,7 +42,8 @@ int tui_init(const char *device, const char *direction)
     keypad(stdscr, TRUE);
     timeout(100);  /* non-blocking getch, 100ms */
 
-    tui_device = device;
+    tui_ifaces = ifaces;
+    tui_iface_count = iface_count;
     tui_direction = direction;
 
     signal(SIGWINCH, sigwinch_handler);
@@ -83,22 +85,18 @@ static void draw_row(int y, const char *label, int pps, int total,
     attroff(COLOR_PAIR(5));
 }
 
-void tui_update(const packet_counter_t *cur,
-                const packet_counter_t *total,
-                int elapsed_sec, int paused)
+/*
+ * Draw a single-interface view with protocol breakdown and bars.
+ */
+static int draw_single_iface(iface_ctx_t *ctx, int start_row, int paused)
 {
-    int row;
+    int row = start_row;
     int bar_width;
-    double total_kbps;
-    double max_kbps;
+    double total_kbps, max_kbps;
     double kbps_ip, kbps_ipv6, kbps_arp, kbps_icmp, kbps_tcp, kbps_udp;
+    const packet_counter_t *cur = &ctx->pkt_cnt;
+    const packet_counter_t *total = &ctx->total_cnt;
     int h, m, s;
-
-    if (needs_resize) {
-        needs_resize = 0;
-        endwin();
-        refresh();
-    }
 
     bar_width = COLS - 50;
     if (bar_width < 5) bar_width = 5;
@@ -106,10 +104,6 @@ void tui_update(const packet_counter_t *cur,
 
     total_kbps = (double)cur->bps * 8 / 1024;
 
-    /*
-     * Estimate per-protocol bandwidth proportionally from packet counts.
-     * True per-protocol byte tracking would require deeper packet inspection.
-     */
     if (cur->all > 0) {
         kbps_ip   = total_kbps * cur->ip   / cur->all;
         kbps_ipv6 = total_kbps * cur->ipv6 / cur->all;
@@ -123,40 +117,39 @@ void tui_update(const packet_counter_t *cur,
 
     max_kbps = total_kbps > 0 ? total_kbps : 1;
 
-    erase();
-
     /* Header */
-    h = elapsed_sec / 3600;
-    m = (elapsed_sec % 3600) / 60;
-    s = elapsed_sec % 60;
+    h = ctx->elapsed_sec / 3600;
+    m = (ctx->elapsed_sec % 3600) / 60;
+    s = ctx->elapsed_sec % 60;
 
     attron(COLOR_PAIR(2) | A_BOLD);
-    mvprintw(0, 1, " pkt_monitor");
+    mvprintw(row, 1, " pkt_monitor");
     attroff(A_BOLD);
-    printw("  %s  %s  %02d:%02d:%02d", tui_device, tui_direction, h, m, s);
+    printw("  %s  %s  %02d:%02d:%02d", ctx->name, tui_direction, h, m, s);
     if (paused) {
         attron(A_BOLD);
         printw("  [PAUSED]");
         attroff(A_BOLD);
     }
     attroff(COLOR_PAIR(2));
+    row++;
 
     /* Separator */
-    mvhline(1, 1, ACS_HLINE, COLS - 2);
+    mvhline(row, 1, ACS_HLINE, COLS - 2);
+    row += 2;
 
     /* Column headers */
-    row = 3;
     attron(A_BOLD);
     mvprintw(row, 2, "  %-6s  %7s  %9s  %-*s  %13s",
              "Proto", "pkt/s", "Total", bar_width, "Bandwidth", "kbps");
     attroff(A_BOLD);
+    row++;
 
     /* Separator */
-    row++;
     mvhline(row, 2, ACS_HLINE, COLS - 4);
+    row++;
 
     /* Protocol rows */
-    row++;
     draw_row(row++, "IPv4",  cur->ip,   total->ip,   kbps_ip,   max_kbps, bar_width);
     draw_row(row++, "IPv6",  cur->ipv6, total->ipv6, kbps_ipv6, max_kbps, bar_width);
     draw_row(row++, "ARP",   cur->arp,  total->arp,  kbps_arp,  max_kbps, bar_width);
@@ -172,14 +165,120 @@ void tui_update(const packet_counter_t *cur,
     attron(COLOR_PAIR(3) | A_BOLD);
     mvprintw(row, 2, "  %-6s  %7d  %9d", "ALL", cur->all, total->all);
     attroff(COLOR_PAIR(3) | A_BOLD);
-    /* Skip bar for total */
     move(row, 30 + bar_width);
     attron(COLOR_PAIR(5) | A_BOLD);
     printw("  %7.1f kbps", total_kbps);
     attroff(COLOR_PAIR(5) | A_BOLD);
+    row++;
+
+    return row;
+}
+
+/*
+ * Draw a compact multi-interface view: one row per interface.
+ */
+static int draw_multi_iface(iface_ctx_t *ifaces, int count,
+                            int start_row, int paused)
+{
+    int row = start_row;
+    int h, m, s;
+
+    /* Use first iface for elapsed time (all tick together) */
+    h = ifaces[0].elapsed_sec / 3600;
+    m = (ifaces[0].elapsed_sec % 3600) / 60;
+    s = ifaces[0].elapsed_sec % 60;
+
+    /* Header */
+    attron(COLOR_PAIR(2) | A_BOLD);
+    mvprintw(row, 1, " pkt_monitor");
+    attroff(A_BOLD);
+    printw("  %d ifaces  %s  %02d:%02d:%02d", count, tui_direction, h, m, s);
+    if (paused) {
+        attron(A_BOLD);
+        printw("  [PAUSED]");
+        attroff(A_BOLD);
+    }
+    attroff(COLOR_PAIR(2));
+    row++;
+
+    /* Separator */
+    mvhline(row, 1, ACS_HLINE, COLS - 2);
+    row += 2;
+
+    /* Column headers */
+    attron(A_BOLD);
+    mvprintw(row, 2, "  %-10s %5s %5s %5s %4s %4s %5s %5s %9s",
+             "Iface", "all", "IPv4", "IPv6", "ARP", "ICMP", "TCP", "UDP", "kbps");
+    attroff(A_BOLD);
+    row++;
+    mvhline(row, 2, ACS_HLINE, COLS - 4);
+    row++;
+
+    /* Per-second rows */
+    for (int i = 0; i < count; i++) {
+        const packet_counter_t *c = &ifaces[i].pkt_cnt;
+        double kbps = (double)c->bps * 8 / 1024;
+
+        attron(COLOR_PAIR(4));
+        mvprintw(row, 2, "  %-10s %5d %5d %5d %4d %4d %5d %5d",
+                 ifaces[i].name, c->all, c->ip, c->ipv6,
+                 c->arp, c->icmp, c->tcp, c->udp);
+        attroff(COLOR_PAIR(4));
+        attron(COLOR_PAIR(5));
+        printw(" %8.1f", kbps);
+        attroff(COLOR_PAIR(5));
+        row++;
+    }
+
+    /* Separator + totals header */
+    row++;
+    mvhline(row, 2, ACS_HLINE, COLS - 4);
+    row++;
+
+    attron(A_BOLD);
+    mvprintw(row, 2, "  %-10s %5s %5s %5s %4s %4s %5s %5s %9s",
+             "Total", "all", "IPv4", "IPv6", "ARP", "ICMP", "TCP", "UDP", "kbps");
+    attroff(A_BOLD);
+    row++;
+    mvhline(row, 2, ACS_HLINE, COLS - 4);
+    row++;
+
+    for (int i = 0; i < count; i++) {
+        const packet_counter_t *t = &ifaces[i].total_cnt;
+        double kbps = ifaces[i].elapsed_sec > 0
+            ? (double)t->bps * 8 / 1024 / ifaces[i].elapsed_sec : 0;
+
+        attron(COLOR_PAIR(3));
+        mvprintw(row, 2, "  %-10s %5d %5d %5d %4d %4d %5d %5d",
+                 ifaces[i].name, t->all, t->ip, t->ipv6,
+                 t->arp, t->icmp, t->tcp, t->udp);
+        attroff(COLOR_PAIR(3));
+        attron(COLOR_PAIR(5));
+        printw(" %8.1f", kbps);
+        attroff(COLOR_PAIR(5));
+        row++;
+    }
+
+    return row;
+}
+
+void tui_update(iface_ctx_t *ifaces, int iface_count, int paused)
+{
+    if (needs_resize) {
+        needs_resize = 0;
+        endwin();
+        refresh();
+    }
+
+    erase();
+
+    if (iface_count == 1)
+        draw_single_iface(&ifaces[0], 0, paused);
+    else
+        draw_multi_iface(ifaces, iface_count, 0, paused);
 
     /* Footer */
-    row = LINES - 2;
+    int row = LINES - 2;
     mvhline(row - 1, 1, ACS_HLINE, COLS - 2);
     attron(A_DIM);
     mvprintw(row, 2, "[q] Quit  [p] Pause  [r] Reset counters");

--- a/tui.h
+++ b/tui.h
@@ -7,10 +7,9 @@
 
 #include "pkt_monitor.h"
 
-int  tui_init(const char *device, const char *direction);
-void tui_update(const packet_counter_t *current,
-                const packet_counter_t *total,
-                int elapsed_sec, int paused);
+int  tui_init(iface_ctx_t *ifaces, int iface_count, const char *direction);
+void tui_update(iface_ctx_t *ifaces, int iface_count,
+                int paused);
 void tui_cleanup(void);
 int  tui_handle_input(void);  /* returns: 0=continue, 'q'=quit, 'p'=pause, 'r'=reset */
 


### PR DESCRIPTION
## Summary

- **#15**: `-d` を複数回指定して最大 8 インターフェースを同時監視（ラウンドロビン `pcap_dispatch`）
- **#2**: `-f <filter>` オプションで tcpdump 互換の BPF フィルタを指定可能
- `iface_ctx_t` 構造体で各インターフェースが独立した pcap ハンドル・カウンタを保持
- pcap timeout を `100 / iface_count` ms に動的調整（最小 10ms）
- 単一インターフェース時は出力・TUI ともに既存動作を完全維持（後方互換）
- 複数インターフェース時は TUI にコンパクトなテーブル表示を追加
- `-i`/`-o` 方向フィルタも全インターフェースに適用

## Test plan

- [ ] `./pkt_monitor -h` — 新オプションがヘルプに表示されること
- [ ] `sudo ./pkt_monitor -d en0` — 単一インターフェース（後方互換）
- [ ] `sudo ./pkt_monitor -d en0 -f "tcp port 443"` — BPF フィルタ
- [ ] `sudo ./pkt_monitor -d en0 -f "host 192.168.1.1"` — ホストフィルタ
- [ ] `sudo ./pkt_monitor -d en0 -d lo0` — 複数インターフェース同時監視
- [ ] `sudo ./pkt_monitor -d en0 -d lo0 -f "tcp"` — 複数 iface + フィルタ
- [ ] `sudo ./pkt_monitor -d en0 -u` — TUI 単一 iface（バーチャート表示）
- [ ] `sudo ./pkt_monitor -d en0 -d lo0 -u` — TUI 複数 iface（テーブル表示）

🤖 Generated with [Claude Code](https://claude.com/claude-code)