### PR TITLE
feat: add BPF filter, JSON/CSV output, Top-N flows, duration, log, alert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CFLAGS  = -O2 -g -Wall -Wextra -Werror
 LDFLAGS = -lpcap
 PREFIX ?= /usr/local
 
-SRCS = pkt_monitor.c
+SRCS = pkt_monitor.c output.c stats.c
 OBJS = $(SRCS:.c=.o)
 
 # Auto-detect ncurses
@@ -31,6 +31,12 @@ $(PACKAGE): $(OBJS)
 	$(CC) $(CFLAGS) -c $<
 
 tui.o: tui.c tui.h pkt_monitor.h
+	$(CC) $(CFLAGS) -c $<
+
+output.o: output.c output.h pkt_monitor.h
+	$(CC) $(CFLAGS) -c $<
+
+stats.o: stats.c stats.h
 	$(CC) $(CFLAGS) -c $<
 
 clean:

--- a/output.c
+++ b/output.c
@@ -1,0 +1,53 @@
+/*
+ * output.c - Structured output formats (JSON, CSV, log)
+ */
+
+#include <inttypes.h>
+#include "output.h"
+
+void output_json_line(FILE *fp, const packet_counter_t *cur)
+{
+    char timebuf[16];
+
+    get_time_str(timebuf, sizeof(timebuf));
+    fprintf(fp,
+        "{\"time\":\"%s\",\"all\":%" PRIu32 ",\"ipv4\":%" PRIu32
+        ",\"ipv6\":%" PRIu32 ",\"arp\":%" PRIu32 ",\"icmp\":%" PRIu32
+        ",\"tcp\":%" PRIu32 ",\"udp\":%" PRIu32 ",\"kbps\":%.1f}\n",
+        timebuf, cur->all, cur->ip, cur->ipv6, cur->arp,
+        cur->icmp, cur->tcp, cur->udp,
+        (double)cur->bytes * 8.0 / 1024.0);
+    fflush(fp);
+}
+
+void output_csv_header(FILE *fp)
+{
+    fprintf(fp, "time,all,ipv4,ipv6,arp,icmp,tcp,udp,kbps\n");
+    fflush(fp);
+}
+
+void output_csv_line(FILE *fp, const packet_counter_t *cur)
+{
+    char timebuf[16];
+
+    get_time_str(timebuf, sizeof(timebuf));
+    fprintf(fp, "%s,%" PRIu32 ",%" PRIu32 ",%" PRIu32 ",%" PRIu32
+            ",%" PRIu32 ",%" PRIu32 ",%" PRIu32 ",%.1f\n",
+            timebuf, cur->all, cur->ip, cur->ipv6, cur->arp,
+            cur->icmp, cur->tcp, cur->udp,
+            (double)cur->bytes * 8.0 / 1024.0);
+    fflush(fp);
+}
+
+void output_log_line(FILE *fp, const packet_counter_t *cur)
+{
+    char timebuf[16];
+
+    get_time_str(timebuf, sizeof(timebuf));
+    fprintf(fp, "%s\t%" PRIu32 "\t%" PRIu32 "\t%" PRIu32 "\t%" PRIu32
+            "\t%" PRIu32 "\t%" PRIu32 "\t%" PRIu32 "\t%.1fkbps\n",
+            timebuf, cur->all, cur->ip, cur->ipv6, cur->arp,
+            cur->icmp, cur->tcp, cur->udp,
+            (double)cur->bytes * 8.0 / 1024.0);
+    fflush(fp);
+}

--- a/output.h
+++ b/output.h
@@ -1,0 +1,16 @@
+/*
+ * output.h - Structured output formats (JSON, CSV, log)
+ */
+
+#ifndef OUTPUT_H
+#define OUTPUT_H
+
+#include <stdio.h>
+#include "pkt_monitor.h"
+
+void output_json_line(FILE *fp, const packet_counter_t *cur);
+void output_csv_header(FILE *fp);
+void output_csv_line(FILE *fp, const packet_counter_t *cur);
+void output_log_line(FILE *fp, const packet_counter_t *cur);
+
+#endif /* OUTPUT_H */

--- a/pkt_monitor.c
+++ b/pkt_monitor.c
@@ -13,8 +13,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <signal.h>
-#include <time.h>
 #include <unistd.h>
+#include <inttypes.h>
 #include <sys/time.h>
 
 #include <pcap/pcap.h>
@@ -31,110 +31,57 @@
 #endif
 
 #include "pkt_monitor.h"
+#include "output.h"
+#include "stats.h"
 
 #ifdef HAS_NCURSES
 #include "tui.h"
 #endif
 
-#define TIMEOUT_SEC  1
-#define TIMEOUT_USEC 0
-
 /* ---- global state ----------------------------------------------------- */
 
 static iface_ctx_t ifaces[MAX_IFACES];
 static int iface_count;
-static char *filter_expr;
 static volatile sig_atomic_t running = 1;
-
-/*
- * Get current time as HH:MM:SS string.
- */
-static void get_time(char *buf, size_t len)
-{
-    time_t t;
-    struct tm *tm;
-
-    time(&t);
-    tm = localtime(&t);
-    strftime(buf, len, "%H:%M:%S", tm);
-}
+static flow_stats_t *g_flow_stats;  /* non-NULL when -T is active */
 
 /*
  * Accumulate per-second counters into totals for one interface.
+ * Does NOT zero pkt_cnt — caller is responsible for that.
  */
 static void accumulate_totals(iface_ctx_t *ctx)
 {
-    ctx->total_cnt.all  += ctx->pkt_cnt.all;
-    ctx->total_cnt.ip   += ctx->pkt_cnt.ip;
-    ctx->total_cnt.ipv6 += ctx->pkt_cnt.ipv6;
-    ctx->total_cnt.arp  += ctx->pkt_cnt.arp;
-    ctx->total_cnt.icmp += ctx->pkt_cnt.icmp;
-    ctx->total_cnt.tcp  += ctx->pkt_cnt.tcp;
-    ctx->total_cnt.udp  += ctx->pkt_cnt.udp;
-    ctx->total_cnt.bps  += ctx->pkt_cnt.bps;
+    ctx->total_cnt.all   += ctx->pkt_cnt.all;
+    ctx->total_cnt.ip    += ctx->pkt_cnt.ip;
+    ctx->total_cnt.ipv6  += ctx->pkt_cnt.ipv6;
+    ctx->total_cnt.arp   += ctx->pkt_cnt.arp;
+    ctx->total_cnt.icmp  += ctx->pkt_cnt.icmp;
+    ctx->total_cnt.tcp   += ctx->pkt_cnt.tcp;
+    ctx->total_cnt.udp   += ctx->pkt_cnt.udp;
+    ctx->total_cnt.bytes += ctx->pkt_cnt.bytes;
     ctx->elapsed_sec++;
-
-    memset(&ctx->pkt_cnt, 0, sizeof(ctx->pkt_cnt));
 }
 
 /*
- * SIGALRM handler: print stats every second, header every INTVAL seconds.
- * Used only in text mode.
+ * Aggregate counters across all interfaces.
+ * If use_total is non-zero, aggregates total_cnt; otherwise pkt_cnt.
  */
-static void alarm_handler(int sig)
+static void aggregate_counters(packet_counter_t *agg, int use_total)
 {
-    char timebuf[16];
-    static int sec = 1;
     int i;
-
-    (void)sig;
-
-    get_time(timebuf, sizeof(timebuf));
-
-    if ((sec % INTVAL) == 1) {
-        if (iface_count > 1)
-            printf("# time #\tiface\t  all\t ipv4\t ipv6\tarp\ticmp"
-                   "\ttcp\tudp\n");
-        else
-            printf("# time #\t  all\t ipv4\t ipv6\tarp\ticmp\ttcp\tudp\n");
-        sec = 1;
-    }
-
+    memset(agg, 0, sizeof(*agg));
     for (i = 0; i < iface_count; i++) {
-        packet_counter_t *c = &ifaces[i].pkt_cnt;
-        if (iface_count > 1)
-            printf("%s\t%s\t%5d\t%5d\t%5d\t%3d\t%3d\t%5d\t%5d%6.1fkbps\n",
-                   timebuf, ifaces[i].name,
-                   c->all, c->ip, c->ipv6, c->arp, c->icmp,
-                   c->tcp, c->udp, (double)c->bps * 8 / 1024);
-        else
-            printf("%s\t%5d\t%5d\t%5d\t%3d\t%3d\t%5d\t%5d%6.1fkbps\n",
-                   timebuf,
-                   c->all, c->ip, c->ipv6, c->arp, c->icmp,
-                   c->tcp, c->udp, (double)c->bps * 8 / 1024);
+        const packet_counter_t *src = use_total ?
+            &ifaces[i].total_cnt : &ifaces[i].pkt_cnt;
+        agg->all   += src->all;
+        agg->ip    += src->ip;
+        agg->ipv6  += src->ipv6;
+        agg->arp   += src->arp;
+        agg->icmp  += src->icmp;
+        agg->tcp   += src->tcp;
+        agg->udp   += src->udp;
+        agg->bytes += src->bytes;
     }
-
-    sec++;
-
-    for (i = 0; i < iface_count; i++)
-        accumulate_totals(&ifaces[i]);
-}
-
-/*
- * Set up SIGALRM timer for periodic stats output (text mode only).
- */
-static void setup_timer(void)
-{
-    struct itimerval timer;
-
-    signal(SIGALRM, alarm_handler);
-
-    timer.it_interval.tv_sec  = TIMEOUT_SEC;
-    timer.it_interval.tv_usec = TIMEOUT_USEC;
-    timer.it_value.tv_sec     = TIMEOUT_SEC;
-    timer.it_value.tv_usec    = TIMEOUT_USEC;
-
-    setitimer(ITIMER_REAL, &timer, NULL);
 }
 
 /*
@@ -153,7 +100,7 @@ static void packet_handler(u_char *user, const struct pcap_pkthdr *header,
         return;
 
     cnt->all++;
-    cnt->bps += header->len;
+    cnt->bytes += header->len;
 
     eth = (const struct ether_header *)packet;
     ether_type = ntohs(eth->ether_type);
@@ -178,15 +125,36 @@ static void packet_handler(u_char *user, const struct pcap_pkthdr *header,
 
     iph = (const struct ip *)(packet + sizeof(struct ether_header));
 
+    /* Top-N host tracking */
+    if (g_flow_stats)
+        flow_stats_record_host(g_flow_stats,
+                               iph->ip_src.s_addr, iph->ip_dst.s_addr);
+
     switch (iph->ip_p) {
     case IPPROTO_ICMP:
         cnt->icmp++;
         break;
     case IPPROTO_TCP:
         cnt->tcp++;
+        if (g_flow_stats) {
+            unsigned int ip_hlen = (unsigned int)iph->ip_hl * 4;
+            if (header->caplen >= sizeof(struct ether_header) + ip_hlen + 4) {
+                const struct tcphdr *th = (const struct tcphdr *)
+                    (packet + sizeof(struct ether_header) + ip_hlen);
+                flow_stats_record_port(g_flow_stats, ntohs(th->th_dport), 1);
+            }
+        }
         break;
     case IPPROTO_UDP:
         cnt->udp++;
+        if (g_flow_stats) {
+            unsigned int ip_hlen = (unsigned int)iph->ip_hl * 4;
+            if (header->caplen >= sizeof(struct ether_header) + ip_hlen + 4) {
+                const struct udphdr *uh = (const struct udphdr *)
+                    (packet + sizeof(struct ether_header) + ip_hlen);
+                flow_stats_record_port(g_flow_stats, ntohs(uh->uh_dport), 0);
+            }
+        }
         break;
     }
 }
@@ -243,7 +211,7 @@ static int apply_filter(pcap_t *h, const char *iface_name, const char *expr)
 }
 
 /*
- * Get current time in milliseconds (monotonic).
+ * Get current time in milliseconds.
  */
 static long long now_ms(void)
 {
@@ -252,18 +220,192 @@ static long long now_ms(void)
     return (long long)tv.tv_sec * 1000 + tv.tv_usec / 1000;
 }
 
+/*
+ * Print text-mode stats lines (per-interface when multi).
+ */
+static void print_text_lines(int *header_count)
+{
+    char timebuf[16];
+    int i;
+
+    get_time_str(timebuf, sizeof(timebuf));
+
+    if ((*header_count % INTVAL) == 0) {
+        if (iface_count > 1)
+            printf("# time #\tiface\t  all\t ipv4\t ipv6\tarp\ticmp"
+                   "\ttcp\tudp\n");
+        else
+            printf("# time #\t  all\t ipv4\t ipv6\tarp\ticmp\ttcp\tudp\n");
+    }
+    (*header_count)++;
+
+    for (i = 0; i < iface_count; i++) {
+        packet_counter_t *c = &ifaces[i].pkt_cnt;
+        if (iface_count > 1)
+            printf("%s\t%s\t%5" PRIu32 "\t%5" PRIu32 "\t%5" PRIu32
+                   "\t%3" PRIu32 "\t%3" PRIu32 "\t%5" PRIu32
+                   "\t%5" PRIu32 "%6.1fkbps\n",
+                   timebuf, ifaces[i].name,
+                   c->all, c->ip, c->ipv6, c->arp, c->icmp,
+                   c->tcp, c->udp, (double)c->bytes * 8.0 / 1024.0);
+        else
+            printf("%s\t%5" PRIu32 "\t%5" PRIu32 "\t%5" PRIu32
+                   "\t%3" PRIu32 "\t%3" PRIu32 "\t%5" PRIu32
+                   "\t%5" PRIu32 "%6.1fkbps\n",
+                   timebuf,
+                   c->all, c->ip, c->ipv6, c->arp, c->icmp,
+                   c->tcp, c->udp, (double)c->bytes * 8.0 / 1024.0);
+    }
+}
+
+/*
+ * Text mode main loop using pcap_dispatch (non-blocking polling).
+ * Replaces the old SIGALRM-based approach for better signal safety
+ * and to support JSON/CSV/log/alert/duration features.
+ */
+static int run_text(const monitor_config_t *cfg)
+{
+    int header_count = 0;
+    long long last_tick;
+    FILE *logfp = NULL;
+    packet_counter_t agg;
+    double kbps;
+    int i;
+
+    if (cfg->log_file) {
+        logfp = fopen(cfg->log_file, "w");
+        if (!logfp) {
+            perror(cfg->log_file);
+            return 1;
+        }
+    }
+
+    signal(SIGINT,  cleanup_handler);
+    signal(SIGTERM, cleanup_handler);
+
+    if (cfg->csv_mode)
+        output_csv_header(stdout);
+
+    last_tick = now_ms();
+
+    while (running) {
+        /* Round-robin dispatch across all interfaces */
+        for (i = 0; i < iface_count; i++) {
+            int ret = pcap_dispatch(ifaces[i].handle, -1, packet_handler,
+                                    (u_char *)&ifaces[i].pkt_cnt);
+            if (ret == PCAP_ERROR) {
+                fprintf(stderr, "pcap error on %s: %s\n",
+                        ifaces[i].name, pcap_geterr(ifaces[i].handle));
+                running = 0;
+                break;
+            }
+        }
+
+        /* Check for 1-second tick */
+        if (now_ms() - last_tick >= 1000) {
+            last_tick += 1000;
+
+            /* Output per-second data */
+            if (cfg->json_mode || cfg->csv_mode) {
+                aggregate_counters(&agg, 0);
+                if (cfg->json_mode)
+                    output_json_line(stdout, &agg);
+                else
+                    output_csv_line(stdout, &agg);
+            } else {
+                print_text_lines(&header_count);
+            }
+
+            /* Log and alert (need aggregated data) */
+            if (logfp || cfg->alert_kbps > 0) {
+                if (!(cfg->json_mode || cfg->csv_mode))
+                    aggregate_counters(&agg, 0);
+                if (logfp)
+                    output_log_line(logfp, &agg);
+                if (cfg->alert_kbps > 0) {
+                    kbps = (double)agg.bytes * 8.0 / 1024.0;
+                    if (kbps > cfg->alert_kbps)
+                        fprintf(stderr,
+                                "ALERT: %.1f kbps > %.1f kbps threshold\n",
+                                kbps, cfg->alert_kbps);
+                }
+            }
+
+            /* Accumulate totals and reset per-second counters */
+            for (i = 0; i < iface_count; i++) {
+                accumulate_totals(&ifaces[i]);
+                memset(&ifaces[i].pkt_cnt, 0, sizeof(packet_counter_t));
+            }
+
+            if (cfg->duration > 0 && ifaces[0].elapsed_sec >= cfg->duration)
+                break;
+        }
+    }
+
+    if (!cfg->json_mode && !cfg->csv_mode)
+        printf("\n# Capture stopped.\n");
+
+    if (logfp)
+        fclose(logfp);
+
+    return 0;
+}
+
+/*
+ * Print capture summary at exit.
+ */
+static void print_summary(void)
+{
+    packet_counter_t agg;
+    int elapsed, dur, i;
+
+    elapsed = ifaces[0].elapsed_sec;
+    dur = elapsed > 0 ? elapsed : 1;
+
+    aggregate_counters(&agg, 1);
+
+    printf("\n# Capture Summary\n");
+    printf("# Duration: %ds\n", elapsed);
+    if (iface_count > 1) {
+        printf("# Interfaces:");
+        for (i = 0; i < iface_count; i++)
+            printf(" %s", ifaces[i].name);
+        printf("\n");
+    }
+    printf("# Total: %" PRIu32 " packets (IPv4: %" PRIu32
+           ", IPv6: %" PRIu32 ", ARP: %" PRIu32 ")\n",
+           agg.all, agg.ip, agg.ipv6, agg.arp);
+    printf("# Protocols: ICMP: %" PRIu32 ", TCP: %" PRIu32
+           ", UDP: %" PRIu32 "\n",
+           agg.icmp, agg.tcp, agg.udp);
+    printf("# Average: %.1f pkt/s, %.1f kbps\n",
+           (double)agg.all / dur,
+           (double)agg.bytes * 8.0 / 1024.0 / dur);
+}
+
 #ifdef HAS_NCURSES
 /*
  * TUI mode main loop using round-robin pcap_dispatch (non-blocking).
  */
-static int run_tui(const char *dir_str)
+static int run_tui(const monitor_config_t *cfg)
 {
     int paused = 0;
     long long last_tick;
     int action, i;
+    FILE *logfp = NULL;
 
-    if (tui_init(ifaces, iface_count, dir_str) < 0)
+    if (cfg->log_file) {
+        logfp = fopen(cfg->log_file, "w");
+        if (!logfp) {
+            perror(cfg->log_file);
+            return 1;
+        }
+    }
+
+    if (tui_init(cfg) < 0) {
+        if (logfp) fclose(logfp);
         return 1;
+    }
 
     /* Disable SIGALRM in TUI mode */
     signal(SIGALRM, SIG_IGN);
@@ -272,17 +414,21 @@ static int run_tui(const char *dir_str)
     signal(SIGTERM, cleanup_handler);
 
     /* Initial draw */
-    tui_update(ifaces, iface_count, paused);
+    tui_update(ifaces, iface_count, paused, cfg);
 
     last_tick = now_ms();
 
     for (;;) {
+        if (!running)
+            break;
+
         /* Round-robin dispatch across all interfaces */
         for (i = 0; i < iface_count; i++) {
             int ret = pcap_dispatch(ifaces[i].handle, -1, packet_handler,
                                     (u_char *)&ifaces[i].pkt_cnt);
             if (ret == PCAP_ERROR_BREAK) {
                 tui_cleanup();
+                if (logfp) fclose(logfp);
                 return 0;
             }
         }
@@ -291,9 +437,27 @@ static int run_tui(const char *dir_str)
         if (now_ms() - last_tick >= 1000) {
             last_tick += 1000;
             if (!paused) {
+                /* Log before accumulate (uses pkt_cnt) */
+                if (logfp) {
+                    packet_counter_t agg;
+                    aggregate_counters(&agg, 0);
+                    output_log_line(logfp, &agg);
+                }
+
+                /* Accumulate totals (does NOT zero pkt_cnt) */
                 for (i = 0; i < iface_count; i++)
                     accumulate_totals(&ifaces[i]);
-                tui_update(ifaces, iface_count, paused);
+
+                /* Draw TUI (reads both pkt_cnt and total_cnt) */
+                tui_update(ifaces, iface_count, paused, cfg);
+
+                /* Now zero per-second counters */
+                for (i = 0; i < iface_count; i++)
+                    memset(&ifaces[i].pkt_cnt, 0, sizeof(packet_counter_t));
+
+                if (cfg->duration > 0 &&
+                    ifaces[0].elapsed_sec >= cfg->duration)
+                    break;
             }
         }
 
@@ -309,25 +473,52 @@ static int run_tui(const char *dir_str)
                 memset(&ifaces[i].total_cnt, 0, sizeof(packet_counter_t));
                 ifaces[i].elapsed_sec = 0;
             }
-            tui_update(ifaces, iface_count, paused);
+            tui_update(ifaces, iface_count, paused, cfg);
         }
     }
 
     tui_cleanup();
+    if (logfp) fclose(logfp);
     return 0;
 }
 #endif /* HAS_NCURSES */
 
+static void usage(const char *prog)
+{
+    fprintf(stderr,
+            "Usage: %s [-d device [-d device2 ...]] [-i|-o] [-f filter]\n"
+            "       %s [-u] [-j|-c] [-t secs] [-l logfile] [-a kbps] [-T N] [-h]\n"
+            "\n"
+            "  -d device   Network interface (repeatable, max %d)\n"
+            "  -i          Capture incoming packets only\n"
+            "  -o          Capture outgoing packets only\n"
+            "  -f filter   BPF filter expression (tcpdump syntax)\n"
+#ifdef HAS_NCURSES
+            "  -u          TUI mode (ncurses)\n"
+#else
+            "  -u          TUI mode (not available, build with ncurses)\n"
+#endif
+            "  -j          JSON output (one line per second)\n"
+            "  -c          CSV output\n"
+            "  -t secs     Stop after N seconds\n"
+            "  -l logfile  Write stats to log file\n"
+            "  -a kbps     Alert when bandwidth exceeds threshold\n"
+            "  -T N        Show top N hosts/ports at exit\n"
+            "  -h          Show this help\n",
+            prog, prog, MAX_IFACES);
+}
+
 int main(int argc, char *argv[])
 {
     char errbuf[PCAP_ERRBUF_SIZE];
-    int direction = 0; /* 0=both, 1=in, 2=out */
-    int use_tui = 0;
+    monitor_config_t cfg;
     int opt, i;
     const char *dir_str;
     int timeout_ms;
 
-    while ((opt = getopt(argc, argv, "d:f:iouh")) != -1) {
+    memset(&cfg, 0, sizeof(cfg));
+
+    while ((opt = getopt(argc, argv, "d:iof:jt:l:ca:T:uh")) != -1) {
         switch (opt) {
         case 'd':
             if (iface_count >= MAX_IFACES) {
@@ -338,36 +529,60 @@ int main(int argc, char *argv[])
                      sizeof(ifaces[iface_count].name), "%s", optarg);
             iface_count++;
             break;
-        case 'f':
-            filter_expr = optarg;
-            break;
         case 'i':
-            direction = 1;
+            cfg.direction = 1;
             break;
         case 'o':
-            direction = 2;
+            cfg.direction = 2;
+            break;
+        case 'f':
+            cfg.filter_expr = optarg;
+            break;
+        case 'j':
+            cfg.json_mode = 1;
+            break;
+        case 't':
+            cfg.duration = atoi(optarg);
+            if (cfg.duration < 1) {
+                fprintf(stderr, "Error: -t requires a positive integer\n");
+                return 1;
+            }
+            break;
+        case 'l':
+            cfg.log_file = optarg;
+            break;
+        case 'c':
+            cfg.csv_mode = 1;
+            break;
+        case 'a':
+            cfg.alert_kbps = atof(optarg);
+            if (cfg.alert_kbps <= 0) {
+                fprintf(stderr, "Error: -a requires a positive number\n");
+                return 1;
+            }
+            break;
+        case 'T':
+            cfg.top_n = atoi(optarg);
+            if (cfg.top_n < 1) cfg.top_n = 1;
             break;
         case 'u':
-            use_tui = 1;
+            cfg.use_tui = 1;
             break;
         case 'h':
         default:
-            fprintf(stderr,
-                    "Usage: %s [-d device [-d device2 ...]] [-f filter]"
-                    " [-i|-o] [-u] [-h]\n"
-                    "  -d device   Network interface (repeatable, max %d)\n"
-                    "  -f filter   BPF filter expression (tcpdump syntax)\n"
-                    "  -i          Capture incoming packets only\n"
-                    "  -o          Capture outgoing packets only\n"
-#ifdef HAS_NCURSES
-                    "  -u          TUI mode (ncurses)\n"
-#else
-                    "  -u          TUI mode (not available, build with ncurses)\n"
-#endif
-                    "  -h          Show this help\n",
-                    argv[0], MAX_IFACES);
+            usage(argv[0]);
             return (opt == 'h') ? 0 : 1;
         }
+    }
+
+    /* Validate mutually exclusive options */
+    if (cfg.use_tui && (cfg.json_mode || cfg.csv_mode)) {
+        fprintf(stderr, "Error: -u cannot be combined with -j or -c\n");
+        return 1;
+    }
+    if (cfg.json_mode && cfg.csv_mode) {
+        fprintf(stderr, "Error: -j and -c are mutually exclusive\n");
+        return 1;
     }
 
     /* Legacy positional argument support: pkt_monitor <device> */
@@ -387,13 +602,13 @@ int main(int argc, char *argv[])
         snprintf(ifaces[0].name, sizeof(ifaces[0].name), "%s", alldevs->name);
         iface_count = 1;
         pcap_freealldevs(alldevs);
-        if (!use_tui)
+        if (!cfg.use_tui)
             printf("# auto-detected device: %s\n", ifaces[0].name);
     }
 
     /* TUI requires ncurses */
 #ifndef HAS_NCURSES
-    if (use_tui) {
+    if (cfg.use_tui) {
         fprintf(stderr, "TUI mode not available. Rebuild with ncurses support.\n");
         return 1;
     }
@@ -429,32 +644,48 @@ int main(int argc, char *argv[])
         }
 
         /* Set capture direction if requested */
-        if (direction == 1) {
+        if (cfg.direction == 1) {
             if (pcap_setdirection(ifaces[i].handle, PCAP_D_IN) == -1)
                 fprintf(stderr, "Warning: %s: cannot set direction to inbound: %s\n",
                         ifaces[i].name, pcap_geterr(ifaces[i].handle));
-        } else if (direction == 2) {
+        } else if (cfg.direction == 2) {
             if (pcap_setdirection(ifaces[i].handle, PCAP_D_OUT) == -1)
                 fprintf(stderr, "Warning: %s: cannot set direction to outbound: %s\n",
                         ifaces[i].name, pcap_geterr(ifaces[i].handle));
         }
 
         /* Apply BPF filter */
-        if (filter_expr) {
+        if (cfg.filter_expr) {
             if (apply_filter(ifaces[i].handle, ifaces[i].name,
-                             filter_expr) == -1) {
+                             cfg.filter_expr) == -1) {
                 cleanup_all();
                 return 1;
             }
         }
     }
 
-    dir_str = direction == 0 ? "both" : direction == 1 ? "in" : "out";
+    dir_str = cfg.direction == 0 ? "both" : cfg.direction == 1 ? "in" : "out";
+
+    /* Initialize Top-N tracking if requested */
+    if (cfg.top_n > 0) {
+        static flow_stats_t fs;
+        if (flow_stats_init(&fs) < 0) {
+            fprintf(stderr, "Warning: failed to allocate flow stats\n");
+        } else {
+            g_flow_stats = &fs;
+        }
+    }
 
 #ifdef HAS_NCURSES
-    if (use_tui) {
-        int ret = run_tui(dir_str);
+    if (cfg.use_tui) {
+        int ret = run_tui(&cfg);
         cleanup_all();
+        if (ret == 0)
+            print_summary();
+        if (ret == 0 && g_flow_stats)
+            flow_stats_print(g_flow_stats, cfg.top_n);
+        if (g_flow_stats)
+            flow_stats_cleanup(g_flow_stats);
         return ret;
     }
 #endif
@@ -469,31 +700,19 @@ int main(int argc, char *argv[])
                    i < iface_count - 1 ? "," : "");
         printf(" (direction: %s)", dir_str);
     }
-    if (filter_expr)
-        printf(" [filter: %s]", filter_expr);
+    if (cfg.filter_expr)
+        printf(" [filter: %s]", cfg.filter_expr);
     printf("\n");
 
-    setup_timer();
-
-    signal(SIGINT,  cleanup_handler);
-    signal(SIGTERM, cleanup_handler);
-
-    /* Round-robin dispatch */
-    while (running) {
-        for (i = 0; i < iface_count; i++) {
-            int ret = pcap_dispatch(ifaces[i].handle, -1, packet_handler,
-                                    (u_char *)&ifaces[i].pkt_cnt);
-            if (ret == PCAP_ERROR) {
-                fprintf(stderr, "pcap error on %s: %s\n",
-                        ifaces[i].name, pcap_geterr(ifaces[i].handle));
-                running = 0;
-                break;
-            }
-        }
+    {
+        int ret = run_text(&cfg);
+        cleanup_all();
+        if (ret == 0 && !cfg.json_mode && !cfg.csv_mode)
+            print_summary();
+        if (ret == 0 && g_flow_stats)
+            flow_stats_print(g_flow_stats, cfg.top_n);
+        if (g_flow_stats)
+            flow_stats_cleanup(g_flow_stats);
+        return ret;
     }
-
-    cleanup_all();
-    printf("\n# Capture stopped.\n");
-
-    return 0;
 }

--- a/pkt_monitor.h
+++ b/pkt_monitor.h
@@ -5,6 +5,8 @@
 #ifndef PKT_MONITOR_H
 #define PKT_MONITOR_H
 
+#include <stdint.h>
+#include <time.h>
 #include <pcap/pcap.h>
 
 #define SNAP_LEN     1600
@@ -12,14 +14,14 @@
 #define MAX_IFACES   8
 
 typedef struct {
-    int all;
-    int ip;
-    int ipv6;
-    int arp;
-    int icmp;
-    int tcp;
-    int udp;
-    int bps;
+    uint32_t all;
+    uint32_t ip;
+    uint32_t ipv6;
+    uint32_t arp;
+    uint32_t icmp;
+    uint32_t tcp;
+    uint32_t udp;
+    uint64_t bytes;
 } packet_counter_t;
 
 typedef struct {
@@ -29,5 +31,24 @@ typedef struct {
     packet_counter_t total_cnt;   /* cumulative */
     int              elapsed_sec;
 } iface_ctx_t;
+
+typedef struct {
+    const char *filter_expr;    /* -f: BPF filter */
+    const char *log_file;       /* -l: log file path */
+    int         direction;      /* 0=both, 1=in, 2=out */
+    int         use_tui;        /* -u */
+    int         json_mode;      /* -j */
+    int         csv_mode;       /* -c */
+    int         duration;       /* -t: seconds, 0=unlimited */
+    double      alert_kbps;     /* -a: threshold, 0=disabled */
+    int         top_n;          /* -T: 0=disabled */
+} monitor_config_t;
+
+static inline void get_time_str(char *buf, size_t len)
+{
+    time_t t = time(NULL);
+    struct tm *tm = localtime(&t);
+    strftime(buf, len, "%H:%M:%S", tm);
+}
 
 #endif /* PKT_MONITOR_H */

--- a/stats.c
+++ b/stats.c
@@ -1,0 +1,247 @@
+/*
+ * stats.c - Host and port tracking for Top-N flow analysis
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+#include <arpa/inet.h>
+
+#include "stats.h"
+
+/* ---- well-known port names -------------------------------------------- */
+
+typedef struct { uint16_t port; const char *name; } port_name_t;
+
+static const port_name_t well_known[] = {
+    {   20, "FTP-DATA"   }, {   21, "FTP"        }, {   22, "SSH"        },
+    {   23, "TELNET"     }, {   25, "SMTP"       }, {   53, "DNS"        },
+    {   67, "DHCP-S"     }, {   68, "DHCP-C"     }, {   80, "HTTP"       },
+    {  110, "POP3"       }, {  123, "NTP"        }, {  143, "IMAP"       },
+    {  161, "SNMP"       }, {  443, "HTTPS"      }, {  445, "SMB"        },
+    {  465, "SMTPS"      }, {  587, "SUBMISSION"  },
+    {  993, "IMAPS"      }, {  995, "POP3S"      },
+    { 1433, "MSSQL"      }, { 3306, "MySQL"      }, { 3389, "RDP"        },
+    { 5432, "PostgreSQL" }, { 5900, "VNC"        },
+    { 6379, "Redis"      }, { 8080, "HTTP-ALT"   }, { 8443, "HTTPS-ALT"  },
+    { 8888, "HTTP-ALT2"  }, { 9090, "Prometheus" }, {27017, "MongoDB"    },
+    { 0, NULL }
+};
+
+static const char *port_service_name(uint16_t port)
+{
+    const port_name_t *p;
+    for (p = well_known; p->name; p++)
+        if (p->port == port) return p->name;
+    return NULL;
+}
+
+/* ---- lifecycle -------------------------------------------------------- */
+
+int flow_stats_init(flow_stats_t *fs)
+{
+    memset(&fs->hosts, 0, sizeof(fs->hosts));
+
+    fs->ports.tcp_dst = calloc(PORT_COUNT, sizeof(uint32_t));
+    fs->ports.udp_dst = calloc(PORT_COUNT, sizeof(uint32_t));
+
+    if (!fs->ports.tcp_dst || !fs->ports.udp_dst) {
+        free(fs->ports.tcp_dst);
+        free(fs->ports.udp_dst);
+        fs->ports.tcp_dst = NULL;
+        fs->ports.udp_dst = NULL;
+        return -1;
+    }
+
+    return 0;
+}
+
+void flow_stats_cleanup(flow_stats_t *fs)
+{
+    free(fs->ports.tcp_dst);
+    free(fs->ports.udp_dst);
+    fs->ports.tcp_dst = NULL;
+    fs->ports.udp_dst = NULL;
+}
+
+/* ---- host tracking (open-addressing hash table) ----------------------- */
+
+static uint32_t host_hash(uint32_t addr)
+{
+    uint32_t h = addr;
+    h ^= h >> 16;
+    h *= 0x45d9f3b;
+    h ^= h >> 16;
+    return h & (HOST_TABLE_SIZE - 1);
+}
+
+static host_entry_t *host_find_or_insert(host_table_t *ht, uint32_t addr)
+{
+    uint32_t idx, slot;
+    int i;
+
+    if (addr == 0) return NULL;
+
+    idx = host_hash(addr);
+
+    for (i = 0; i < HOST_TABLE_SIZE; i++) {
+        slot = (idx + (uint32_t)i) & (HOST_TABLE_SIZE - 1);
+
+        if (ht->slots[slot].addr == addr)
+            return &ht->slots[slot];
+
+        if (ht->slots[slot].addr == 0) {
+            if (ht->count >= HOST_TABLE_MAX)
+                return NULL;        /* table full */
+            ht->slots[slot].addr = addr;
+            ht->count++;
+            return &ht->slots[slot];
+        }
+    }
+    return NULL;
+}
+
+void flow_stats_record_host(flow_stats_t *fs, uint32_t src, uint32_t dst)
+{
+    host_entry_t *e;
+
+    e = host_find_or_insert(&fs->hosts, src);
+    if (e) e->pkts_src++;
+
+    e = host_find_or_insert(&fs->hosts, dst);
+    if (e) e->pkts_dst++;
+}
+
+/* ---- port tracking ---------------------------------------------------- */
+
+void flow_stats_record_port(flow_stats_t *fs, uint16_t port, int is_tcp)
+{
+    if (!fs->ports.tcp_dst || !fs->ports.udp_dst)
+        return;
+
+    if (is_tcp)
+        fs->ports.tcp_dst[port]++;
+    else
+        fs->ports.udp_dst[port]++;
+}
+
+/* ---- summary output --------------------------------------------------- */
+
+typedef struct {
+    uint32_t addr;
+    uint32_t total;
+    uint32_t pkts_src;
+    uint32_t pkts_dst;
+} host_sort_t;
+
+static int cmp_host_desc(const void *a, const void *b)
+{
+    const host_sort_t *ha = a, *hb = b;
+    if (hb->total > ha->total) return  1;
+    if (hb->total < ha->total) return -1;
+    return 0;
+}
+
+typedef struct {
+    uint16_t port;
+    uint32_t count;
+    int      is_tcp;
+} port_sort_t;
+
+static int cmp_port_desc(const void *a, const void *b)
+{
+    const port_sort_t *pa = a, *pb = b;
+    if (pb->count > pa->count) return  1;
+    if (pb->count < pa->count) return -1;
+    return 0;
+}
+
+void flow_stats_print(const flow_stats_t *fs, int top_n)
+{
+    int i;
+
+    /* Top-N hosts */
+    if (fs->hosts.count > 0) {
+        host_sort_t *harr;
+        int hcount = 0;
+        int show;
+
+        harr = malloc(sizeof(host_sort_t) * (size_t)fs->hosts.count);
+        if (!harr) return;
+
+        for (i = 0; i < HOST_TABLE_SIZE; i++) {
+            if (fs->hosts.slots[i].addr != 0) {
+                harr[hcount].addr     = fs->hosts.slots[i].addr;
+                harr[hcount].pkts_src = fs->hosts.slots[i].pkts_src;
+                harr[hcount].pkts_dst = fs->hosts.slots[i].pkts_dst;
+                harr[hcount].total    = fs->hosts.slots[i].pkts_src +
+                                        fs->hosts.slots[i].pkts_dst;
+                hcount++;
+            }
+        }
+
+        qsort(harr, (size_t)hcount, sizeof(host_sort_t), cmp_host_desc);
+
+        show = hcount < top_n ? hcount : top_n;
+        printf("\n# Top %d hosts:\n", show);
+        for (i = 0; i < show; i++) {
+            struct in_addr a;
+            a.s_addr = harr[i].addr;
+            printf("#   %d. %-15s  %" PRIu32 " pkts (src: %" PRIu32
+                   ", dst: %" PRIu32 ")\n",
+                   i + 1, inet_ntoa(a), harr[i].total,
+                   harr[i].pkts_src, harr[i].pkts_dst);
+        }
+        free(harr);
+    }
+
+    /* Top-N ports */
+    if (fs->ports.tcp_dst && fs->ports.udp_dst) {
+        int pcount = 0;
+        port_sort_t *parr;
+        int pi = 0;
+        int show;
+
+        for (i = 0; i < PORT_COUNT; i++) {
+            if (fs->ports.tcp_dst[i] > 0) pcount++;
+            if (fs->ports.udp_dst[i] > 0) pcount++;
+        }
+
+        if (pcount > 0) {
+            parr = malloc(sizeof(port_sort_t) * (size_t)pcount);
+            if (!parr) return;
+
+            for (i = 0; i < PORT_COUNT; i++) {
+                if (fs->ports.tcp_dst[i] > 0) {
+                    parr[pi].port   = (uint16_t)i;
+                    parr[pi].count  = fs->ports.tcp_dst[i];
+                    parr[pi].is_tcp = 1;
+                    pi++;
+                }
+                if (fs->ports.udp_dst[i] > 0) {
+                    parr[pi].port   = (uint16_t)i;
+                    parr[pi].count  = fs->ports.udp_dst[i];
+                    parr[pi].is_tcp = 0;
+                    pi++;
+                }
+            }
+
+            qsort(parr, (size_t)pi, sizeof(port_sort_t), cmp_port_desc);
+
+            show = pi < top_n ? pi : top_n;
+            printf("\n# Top %d ports:\n", show);
+            for (i = 0; i < show; i++) {
+                const char *svc = port_service_name(parr[i].port);
+                printf("#   %5d/%s", parr[i].port,
+                       parr[i].is_tcp ? "tcp" : "udp");
+                if (svc)
+                    printf(" (%-12s)", svc);
+                else
+                    printf("               ");
+                printf("  %" PRIu32 " pkts\n", parr[i].count);
+            }
+            free(parr);
+        }
+    }
+}

--- a/stats.h
+++ b/stats.h
@@ -1,0 +1,41 @@
+/*
+ * stats.h - Host and port tracking for Top-N flow analysis
+ */
+
+#ifndef STATS_H
+#define STATS_H
+
+#include <stdint.h>
+
+#define HOST_TABLE_SIZE  4096   /* must be power of 2 */
+#define HOST_TABLE_MAX   3072   /* 75% load factor */
+#define PORT_COUNT       65536
+
+typedef struct {
+    uint32_t addr;          /* IPv4 (network byte order), 0 = empty */
+    uint32_t pkts_src;
+    uint32_t pkts_dst;
+} host_entry_t;
+
+typedef struct {
+    host_entry_t slots[HOST_TABLE_SIZE];
+    int count;
+} host_table_t;
+
+typedef struct {
+    uint32_t *tcp_dst;      /* PORT_COUNT entries, malloc'd */
+    uint32_t *udp_dst;      /* PORT_COUNT entries, malloc'd */
+} port_table_t;
+
+typedef struct {
+    host_table_t hosts;
+    port_table_t ports;
+} flow_stats_t;
+
+int  flow_stats_init(flow_stats_t *fs);
+void flow_stats_cleanup(flow_stats_t *fs);
+void flow_stats_record_host(flow_stats_t *fs, uint32_t src, uint32_t dst);
+void flow_stats_record_port(flow_stats_t *fs, uint16_t port, int is_tcp);
+void flow_stats_print(const flow_stats_t *fs, int top_n);
+
+#endif /* STATS_H */

--- a/tui.c
+++ b/tui.c
@@ -7,14 +7,13 @@
 #include <ncurses.h>
 #include <string.h>
 #include <signal.h>
+#include <inttypes.h>
 #include "tui.h"
 
 #define MIN_WIDTH  60
 #define MIN_HEIGHT 15
 #define BAR_MAX    20
 
-static iface_ctx_t *tui_ifaces;
-static int tui_iface_count;
 static const char *tui_direction;
 static volatile sig_atomic_t needs_resize = 0;
 
@@ -24,8 +23,11 @@ static void sigwinch_handler(int sig)
     needs_resize = 1;
 }
 
-int tui_init(iface_ctx_t *ifaces, int iface_count, const char *direction)
+int tui_init(const monitor_config_t *cfg)
 {
+    tui_direction = cfg->direction == 0 ? "both" :
+                    cfg->direction == 1 ? "in" : "out";
+
     initscr();
     if (has_colors()) {
         start_color();
@@ -35,16 +37,13 @@ int tui_init(iface_ctx_t *ifaces, int iface_count, const char *direction)
         init_pair(3, COLOR_YELLOW,  -1);  /* totals */
         init_pair(4, COLOR_WHITE,   -1);  /* normal */
         init_pair(5, COLOR_MAGENTA, -1);  /* kbps */
+        init_pair(6, COLOR_RED,     -1);  /* alert */
     }
-    cbreak();
+    raw();      /* raw mode: Ctrl+C comes as char 3 instead of SIGINT */
     noecho();
     curs_set(0);
     keypad(stdscr, TRUE);
     timeout(100);  /* non-blocking getch, 100ms */
-
-    tui_ifaces = ifaces;
-    tui_iface_count = iface_count;
-    tui_direction = direction;
 
     signal(SIGWINCH, sigwinch_handler);
 
@@ -75,10 +74,10 @@ static void draw_bar(int y, int x, int width, double ratio)
         addch(ACS_BULLET);
 }
 
-static void draw_row(int y, const char *label, int pps, int total,
+static void draw_row(int y, const char *label, uint32_t pps, uint32_t total,
                      double kbps, double max_kbps, int bar_width)
 {
-    mvprintw(y, 2, "  %-6s  %7d  %9d  ", label, pps, total);
+    mvprintw(y, 2, "  %-6s  %7" PRIu32 "  %9" PRIu32 "  ", label, pps, total);
     draw_bar(y, 30, bar_width, max_kbps > 0 ? kbps / max_kbps : 0);
     attron(COLOR_PAIR(5));
     printw("  %7.1f kbps", kbps);
@@ -86,9 +85,80 @@ static void draw_row(int y, const char *label, int pps, int total,
 }
 
 /*
+ * Draw common header: name, direction, elapsed, filter, duration countdown.
+ * Returns the next available row.
+ */
+static int draw_header(const char *title, int elapsed_sec, int paused,
+                       const monitor_config_t *cfg)
+{
+    int row = 0;
+    int h, m, s;
+
+    h = elapsed_sec / 3600;
+    m = (elapsed_sec % 3600) / 60;
+    s = elapsed_sec % 60;
+
+    attron(COLOR_PAIR(2) | A_BOLD);
+    mvprintw(row, 1, " pkt_monitor");
+    attroff(A_BOLD);
+    printw("  %s  %s  %02d:%02d:%02d", title, tui_direction, h, m, s);
+
+    /* Duration remaining */
+    if (cfg->duration > 0) {
+        int rem = cfg->duration - elapsed_sec;
+        int rh, rm2, rs;
+        if (rem < 0) rem = 0;
+        rh = rem / 3600;
+        rm2 = (rem % 3600) / 60;
+        rs = rem % 60;
+        printw("  [-%02d:%02d:%02d]", rh, rm2, rs);
+    }
+
+    if (paused) {
+        attron(A_BOLD);
+        printw("  [PAUSED]");
+        attroff(A_BOLD);
+    }
+    attroff(COLOR_PAIR(2));
+    row++;
+
+    /* Filter info */
+    if (cfg->filter_expr) {
+        attron(A_DIM);
+        mvprintw(row, 2, "filter: %s", cfg->filter_expr);
+        attroff(A_DIM);
+    }
+    row++;
+
+    /* Separator */
+    mvhline(row, 1, ACS_HLINE, COLS - 2);
+    row += 2;
+
+    return row;
+}
+
+/*
+ * Draw alert if bandwidth exceeds threshold.
+ * Returns the next available row.
+ */
+static int draw_alert(int row, double total_kbps, const monitor_config_t *cfg)
+{
+    if (cfg->alert_kbps > 0 && total_kbps > cfg->alert_kbps) {
+        row += 1;
+        attron(COLOR_PAIR(6) | A_BOLD);
+        mvprintw(row, 2, " ALERT: %.1f kbps > %.1f kbps threshold ",
+                 total_kbps, cfg->alert_kbps);
+        attroff(COLOR_PAIR(6) | A_BOLD);
+        row++;
+    }
+    return row;
+}
+
+/*
  * Draw a single-interface view with protocol breakdown and bars.
  */
-static int draw_single_iface(iface_ctx_t *ctx, int start_row, int paused)
+static int draw_single_iface(iface_ctx_t *ctx, int start_row,
+                              const monitor_config_t *cfg)
 {
     int row = start_row;
     int bar_width;
@@ -96,13 +166,12 @@ static int draw_single_iface(iface_ctx_t *ctx, int start_row, int paused)
     double kbps_ip, kbps_ipv6, kbps_arp, kbps_icmp, kbps_tcp, kbps_udp;
     const packet_counter_t *cur = &ctx->pkt_cnt;
     const packet_counter_t *total = &ctx->total_cnt;
-    int h, m, s;
 
     bar_width = COLS - 50;
     if (bar_width < 5) bar_width = 5;
     if (bar_width > BAR_MAX) bar_width = BAR_MAX;
 
-    total_kbps = (double)cur->bps * 8 / 1024;
+    total_kbps = (double)cur->bytes * 8.0 / 1024.0;
 
     if (cur->all > 0) {
         kbps_ip   = total_kbps * cur->ip   / cur->all;
@@ -116,27 +185,6 @@ static int draw_single_iface(iface_ctx_t *ctx, int start_row, int paused)
     }
 
     max_kbps = total_kbps > 0 ? total_kbps : 1;
-
-    /* Header */
-    h = ctx->elapsed_sec / 3600;
-    m = (ctx->elapsed_sec % 3600) / 60;
-    s = ctx->elapsed_sec % 60;
-
-    attron(COLOR_PAIR(2) | A_BOLD);
-    mvprintw(row, 1, " pkt_monitor");
-    attroff(A_BOLD);
-    printw("  %s  %s  %02d:%02d:%02d", ctx->name, tui_direction, h, m, s);
-    if (paused) {
-        attron(A_BOLD);
-        printw("  [PAUSED]");
-        attroff(A_BOLD);
-    }
-    attroff(COLOR_PAIR(2));
-    row++;
-
-    /* Separator */
-    mvhline(row, 1, ACS_HLINE, COLS - 2);
-    row += 2;
 
     /* Column headers */
     attron(A_BOLD);
@@ -163,13 +211,16 @@ static int draw_single_iface(iface_ctx_t *ctx, int start_row, int paused)
 
     /* Total row */
     attron(COLOR_PAIR(3) | A_BOLD);
-    mvprintw(row, 2, "  %-6s  %7d  %9d", "ALL", cur->all, total->all);
+    mvprintw(row, 2, "  %-6s  %7" PRIu32 "  %9" PRIu32, "ALL", cur->all, total->all);
     attroff(COLOR_PAIR(3) | A_BOLD);
     move(row, 30 + bar_width);
     attron(COLOR_PAIR(5) | A_BOLD);
     printw("  %7.1f kbps", total_kbps);
     attroff(COLOR_PAIR(5) | A_BOLD);
     row++;
+
+    /* Alert */
+    row = draw_alert(row, total_kbps, cfg);
 
     return row;
 }
@@ -178,32 +229,11 @@ static int draw_single_iface(iface_ctx_t *ctx, int start_row, int paused)
  * Draw a compact multi-interface view: one row per interface.
  */
 static int draw_multi_iface(iface_ctx_t *ifaces, int count,
-                            int start_row, int paused)
+                            int start_row, const monitor_config_t *cfg)
 {
     int row = start_row;
-    int h, m, s;
-
-    /* Use first iface for elapsed time (all tick together) */
-    h = ifaces[0].elapsed_sec / 3600;
-    m = (ifaces[0].elapsed_sec % 3600) / 60;
-    s = ifaces[0].elapsed_sec % 60;
-
-    /* Header */
-    attron(COLOR_PAIR(2) | A_BOLD);
-    mvprintw(row, 1, " pkt_monitor");
-    attroff(A_BOLD);
-    printw("  %d ifaces  %s  %02d:%02d:%02d", count, tui_direction, h, m, s);
-    if (paused) {
-        attron(A_BOLD);
-        printw("  [PAUSED]");
-        attroff(A_BOLD);
-    }
-    attroff(COLOR_PAIR(2));
-    row++;
-
-    /* Separator */
-    mvhline(row, 1, ACS_HLINE, COLS - 2);
-    row += 2;
+    double total_agg_kbps = 0;
+    int i;
 
     /* Column headers */
     attron(A_BOLD);
@@ -215,12 +245,14 @@ static int draw_multi_iface(iface_ctx_t *ifaces, int count,
     row++;
 
     /* Per-second rows */
-    for (int i = 0; i < count; i++) {
+    for (i = 0; i < count; i++) {
         const packet_counter_t *c = &ifaces[i].pkt_cnt;
-        double kbps = (double)c->bps * 8 / 1024;
+        double kbps = (double)c->bytes * 8.0 / 1024.0;
+        total_agg_kbps += kbps;
 
         attron(COLOR_PAIR(4));
-        mvprintw(row, 2, "  %-10s %5d %5d %5d %4d %4d %5d %5d",
+        mvprintw(row, 2, "  %-10s %5" PRIu32 " %5" PRIu32 " %5" PRIu32
+                 " %4" PRIu32 " %4" PRIu32 " %5" PRIu32 " %5" PRIu32,
                  ifaces[i].name, c->all, c->ip, c->ipv6,
                  c->arp, c->icmp, c->tcp, c->udp);
         attroff(COLOR_PAIR(4));
@@ -243,13 +275,14 @@ static int draw_multi_iface(iface_ctx_t *ifaces, int count,
     mvhline(row, 2, ACS_HLINE, COLS - 4);
     row++;
 
-    for (int i = 0; i < count; i++) {
+    for (i = 0; i < count; i++) {
         const packet_counter_t *t = &ifaces[i].total_cnt;
         double kbps = ifaces[i].elapsed_sec > 0
-            ? (double)t->bps * 8 / 1024 / ifaces[i].elapsed_sec : 0;
+            ? (double)t->bytes * 8.0 / 1024.0 / ifaces[i].elapsed_sec : 0;
 
         attron(COLOR_PAIR(3));
-        mvprintw(row, 2, "  %-10s %5d %5d %5d %4d %4d %5d %5d",
+        mvprintw(row, 2, "  %-10s %5" PRIu32 " %5" PRIu32 " %5" PRIu32
+                 " %4" PRIu32 " %4" PRIu32 " %5" PRIu32 " %5" PRIu32,
                  ifaces[i].name, t->all, t->ip, t->ipv6,
                  t->arp, t->icmp, t->tcp, t->udp);
         attroff(COLOR_PAIR(3));
@@ -259,11 +292,19 @@ static int draw_multi_iface(iface_ctx_t *ifaces, int count,
         row++;
     }
 
+    /* Alert */
+    row = draw_alert(row, total_agg_kbps, cfg);
+
     return row;
 }
 
-void tui_update(iface_ctx_t *ifaces, int iface_count, int paused)
+void tui_update(iface_ctx_t *ifaces, int iface_count,
+                int paused, const monitor_config_t *cfg)
 {
+    int row;
+    char title[64];
+    int elapsed;
+
     if (needs_resize) {
         needs_resize = 0;
         endwin();
@@ -272,13 +313,22 @@ void tui_update(iface_ctx_t *ifaces, int iface_count, int paused)
 
     erase();
 
+    /* Build title string */
+    elapsed = ifaces[0].elapsed_sec;
     if (iface_count == 1)
-        draw_single_iface(&ifaces[0], 0, paused);
+        snprintf(title, sizeof(title), "%s", ifaces[0].name);
     else
-        draw_multi_iface(ifaces, iface_count, 0, paused);
+        snprintf(title, sizeof(title), "%d ifaces", iface_count);
+
+    row = draw_header(title, elapsed, paused, cfg);
+
+    if (iface_count == 1)
+        draw_single_iface(&ifaces[0], row, cfg);
+    else
+        draw_multi_iface(ifaces, iface_count, row, cfg);
 
     /* Footer */
-    int row = LINES - 2;
+    row = LINES - 2;
     mvhline(row - 1, 1, ACS_HLINE, COLS - 2);
     attron(A_DIM);
     mvprintw(row, 2, "[q] Quit  [p] Pause  [r] Reset counters");
@@ -292,7 +342,7 @@ int tui_handle_input(void)
     int ch = getch();
     if (ch == ERR)
         return 0;
-    if (ch == 'q' || ch == 'Q')
+    if (ch == 'q' || ch == 'Q' || ch == 3 /* Ctrl+C */)
         return 'q';
     if (ch == 'p' || ch == 'P')
         return 'p';

--- a/tui.h
+++ b/tui.h
@@ -7,9 +7,9 @@
 
 #include "pkt_monitor.h"
 
-int  tui_init(iface_ctx_t *ifaces, int iface_count, const char *direction);
+int  tui_init(const monitor_config_t *cfg);
 void tui_update(iface_ctx_t *ifaces, int iface_count,
-                int paused);
+                int paused, const monitor_config_t *cfg);
 void tui_cleanup(void);
 int  tui_handle_input(void);  /* returns: 0=continue, 'q'=quit, 'p'=pause, 'r'=reset */
 


### PR DESCRIPTION
## Summary

- **BPF フィルタ** (`-f "expr"`): tcpdump 構文対応、TUI ヘッダーにも表示
- **JSON 出力** (`-j`): 1秒1行の構造化出力、`jq` でパイプ処理可能
- **CSV 出力** (`-c`): ヘッダー+データ行、gnuplot/スプレッドシート連携用
- **期間指定** (`-t N`): N秒後に自動停止、TUI に残り時間表示
- **ログファイル** (`-l file`): TUI 表示しながら並行でファイル記録
- **閾値アラート** (`-a kbps`): テキスト→stderr、TUI→赤色表示
- **終了時サマリー**: 総パケット数・平均 pps/kbps を自動表示
- **Top-N フロー** (`-T N`): ホスト別・ポート別 Top-N (well-known サービス名付き)

### アーキテクチャ変更
- テキストモードを `pcap_loop()+SIGALRM` → `pcap_dispatch()` ポーリングに変換（TUI と同一モデル）
- 新モジュール: `output.c` (JSON/CSV/ログ)、`stats.c` (ホスト/ポートハッシュテーブル)
- カウンタ型を `int` → `uint32_t`/`uint64_t` に移行（`bps` → `bytes` にリネーム）
- 全 CLI オプションを `monitor_config_t` 構造体に集約

## Test plan

- [ ] `make clean && make` がエラーなしで通ること
- [ ] `sudo ./pkt_monitor -h` で全オプションが表示されること
- [ ] `sudo ./pkt_monitor -f "port 443" -t 5` でフィルタ + 自動停止
- [ ] `sudo ./pkt_monitor -j -t 5 | jq .` で JSON 出力確認
- [ ] `sudo ./pkt_monitor -c -t 5 > out.csv && cat out.csv` で CSV 確認
- [ ] `sudo ./pkt_monitor -u -l /tmp/pkt.log -t 10` で TUI + ログ並行確認
- [ ] `sudo ./pkt_monitor -T 5 -t 10` で Top-N ホスト/ポート表示確認
- [ ] `-j -c` 同時指定でエラーになること
- [ ] `-u -j` 同時指定でエラーになること

🤖 Generated with [Claude Code](https://claude.com/claude-code)