### PR TITLE
feat: add -L flag for layer detail mode foundation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,9 @@ sudo ./pkt_monitor [-d device] [-i|-o] [-u] [-h]
 
 ### Files
 
-- `pkt_monitor.h`: shared types (`packet_counter_t`) and constants
+- `pkt_monitor.h`: shared types (`packet_counter_t`, `monitor_config_t`) and constants
 - `pkt_monitor.c`: main(), capture logic, text mode output, TUI mode loop
+- `layer_detail.h` / `layer_detail.c`: layer detail mode ring buffer and BPF filter builder
 - `tui.h` / `tui.c`: ncurses TUI rendering (compiled only when ncurses is available)
 
 ### Key sections in pkt_monitor.c
@@ -60,6 +61,7 @@ sudo ./pkt_monitor [-d device] [-i|-o] [-u] [-h]
 - TUI mode uses `pcap_dispatch()` (non-blocking, ~100ms timeout) + `gettimeofday()` timer
 - SIGALRM is disabled in TUI mode to avoid ncurses corruption
 - `#ifdef HAS_NCURSES` guards all ncurses code for conditional compilation
+- `-L` layer mode auto-applies BPF filters (L2=arp, L3=ip/ip6/icmp, L4=tcp/udp) and combines with user `-f` filter via AND
 
 ## Important Notes
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CFLAGS  = -O2 -g -Wall -Wextra -Werror
 LDFLAGS = -lpcap
 PREFIX ?= /usr/local
 
-SRCS = pkt_monitor.c output.c stats.c
+SRCS = pkt_monitor.c output.c stats.c layer_detail.c
 OBJS = $(SRCS:.c=.o)
 
 # Auto-detect ncurses
@@ -37,6 +37,9 @@ output.o: output.c output.h pkt_monitor.h
 	$(CC) $(CFLAGS) -c $<
 
 stats.o: stats.c stats.h
+	$(CC) $(CFLAGS) -c $<
+
+layer_detail.o: layer_detail.c layer_detail.h
 	$(CC) $(CFLAGS) -c $<
 
 clean:

--- a/layer_detail.c
+++ b/layer_detail.c
@@ -1,0 +1,69 @@
+/*
+ * layer_detail.c - Layer detail mode: ring buffer and display helpers
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <sys/time.h>
+
+#include "layer_detail.h"
+
+void detail_ring_push(detail_ring_t *ring, const char *line)
+{
+    detail_entry_t *e = &ring->entries[ring->head];
+
+    snprintf(e->line, DETAIL_LINE_LEN, "%s", line);
+    gettimeofday(&e->ts, NULL);
+
+    ring->head = (ring->head + 1) % DETAIL_RING_SIZE;
+    if (ring->count < DETAIL_RING_SIZE)
+        ring->count++;
+}
+
+const detail_entry_t *detail_ring_get(const detail_ring_t *ring, int idx)
+{
+    int pos;
+
+    if (idx < 0 || idx >= ring->count)
+        return NULL;
+
+    if (ring->count < DETAIL_RING_SIZE)
+        pos = idx;
+    else
+        pos = (ring->head + idx) % DETAIL_RING_SIZE;
+
+    return &ring->entries[pos];
+}
+
+void detail_ring_clear(detail_ring_t *ring)
+{
+    ring->head  = 0;
+    ring->count = 0;
+}
+
+const char *layer_build_filter(int layer_mode, const char *user_filter,
+                               char *buf, size_t buflen)
+{
+    const char *layer_filter;
+
+    switch (layer_mode) {
+    case 2:
+        layer_filter = "arp";
+        break;
+    case 3:
+        layer_filter = "ip or ip6 or icmp";
+        break;
+    case 4:
+        layer_filter = "tcp or udp";
+        break;
+    default:
+        return NULL;
+    }
+
+    if (user_filter)
+        snprintf(buf, buflen, "(%s) and (%s)", user_filter, layer_filter);
+    else
+        snprintf(buf, buflen, "%s", layer_filter);
+
+    return buf;
+}

--- a/layer_detail.h
+++ b/layer_detail.h
@@ -1,0 +1,50 @@
+/*
+ * layer_detail.h - Layer detail mode: ring buffer and display helpers
+ */
+
+#ifndef LAYER_DETAIL_H
+#define LAYER_DETAIL_H
+
+#include <sys/time.h>
+
+#define DETAIL_RING_SIZE 64
+#define DETAIL_LINE_LEN  256
+
+typedef struct {
+    char           line[DETAIL_LINE_LEN];  /* formatted display line */
+    struct timeval ts;                      /* timestamp */
+} detail_entry_t;
+
+typedef struct {
+    detail_entry_t entries[DETAIL_RING_SIZE];
+    int head;   /* next write position */
+    int count;  /* entries stored (max DETAIL_RING_SIZE) */
+} detail_ring_t;
+
+/*
+ * Append a formatted line to the ring buffer.
+ * Older entries are overwritten when the buffer is full.
+ */
+void detail_ring_push(detail_ring_t *ring, const char *line);
+
+/*
+ * Get entry at logical index (0 = oldest).
+ * Returns NULL if idx >= count.
+ */
+const detail_entry_t *detail_ring_get(const detail_ring_t *ring, int idx);
+
+/*
+ * Clear all entries.
+ */
+void detail_ring_clear(detail_ring_t *ring);
+
+/*
+ * Build the auto BPF filter string for a given layer mode.
+ * If user_filter is non-NULL, combines as "(user_filter) and (layer_filter)".
+ * The result is written into buf (buflen bytes).
+ * Returns buf on success, NULL if layer_mode is invalid.
+ */
+const char *layer_build_filter(int layer_mode, const char *user_filter,
+                               char *buf, size_t buflen);
+
+#endif /* LAYER_DETAIL_H */

--- a/pkt_monitor.c
+++ b/pkt_monitor.c
@@ -33,6 +33,7 @@
 #include "pkt_monitor.h"
 #include "output.h"
 #include "stats.h"
+#include "layer_detail.h"
 
 #ifdef HAS_NCURSES
 #include "tui.h"
@@ -510,13 +511,14 @@ static int run_tui(const monitor_config_t *cfg)
 static void usage(const char *prog)
 {
     fprintf(stderr,
-            "Usage: %s [-d device [-d device2 ...]] [-i|-o] [-f filter]\n"
+            "Usage: %s [-d device [-d device2 ...]] [-i|-o] [-f filter] [-L 2|3|4]\n"
             "       %s [-r file] [-w file] [-u] [-j|-c] [-t secs] [-l logfile] [-a kbps] [-T N] [-h]\n"
             "\n"
             "  -d device   Network interface (repeatable, max %d)\n"
             "  -i          Capture incoming packets only\n"
             "  -o          Capture outgoing packets only\n"
             "  -f filter   BPF filter expression (tcpdump syntax)\n"
+            "  -L 2|3|4    Layer detail mode (2=ARP, 3=IP/ICMP, 4=TCP/UDP)\n"
             "  -r file     Read packets from pcap file (offline mode)\n"
             "  -w file     Write captured packets to pcap file\n"
 #ifdef HAS_NCURSES
@@ -547,7 +549,7 @@ int main(int argc, char *argv[])
     memset(&cfg, 0, sizeof(cfg));
     cfg.interval_ms = 1000;
 
-    while ((opt = getopt(argc, argv, "d:iof:r:w:jt:l:ca:T:upn:h")) != -1) {
+    while ((opt = getopt(argc, argv, "d:iof:r:w:jt:l:L:ca:T:upn:h")) != -1) {
         switch (opt) {
         case 'd':
             if (iface_count >= MAX_IFACES) {
@@ -600,6 +602,14 @@ int main(int argc, char *argv[])
         case 'w':
             cfg.write_file = optarg;
             break;
+        case 'L':
+            cfg.layer_mode = atoi(optarg);
+            if (cfg.layer_mode != 2 && cfg.layer_mode != 3 &&
+                cfg.layer_mode != 4) {
+                fprintf(stderr, "Error: -L requires 2, 3, or 4\n");
+                return 1;
+            }
+            break;
         case 'u':
             cfg.use_tui = 1;
             break;
@@ -624,6 +634,10 @@ int main(int argc, char *argv[])
     }
 
     /* Validate mutually exclusive options */
+    if (cfg.layer_mode && (cfg.json_mode || cfg.csv_mode)) {
+        fprintf(stderr, "Error: -L cannot be combined with -j or -c\n");
+        return 1;
+    }
     if (cfg.use_tui && (cfg.json_mode || cfg.csv_mode)) {
         fprintf(stderr, "Error: -u cannot be combined with -j or -c\n");
         return 1;
@@ -650,10 +664,24 @@ int main(int argc, char *argv[])
         }
         snprintf(ifaces[0].name, sizeof(ifaces[0].name), "file");
         iface_count = 1;
-        if (cfg.filter_expr) {
-            if (apply_filter(ifaces[0].handle, "file", cfg.filter_expr) == -1) {
-                cleanup_all();
-                return 1;
+        {
+            char layer_fbuf[512];
+            const char *effective_filter = cfg.filter_expr;
+
+            if (cfg.layer_mode) {
+                const char *lf = layer_build_filter(
+                    cfg.layer_mode, cfg.filter_expr,
+                    layer_fbuf, sizeof(layer_fbuf));
+                if (lf)
+                    effective_filter = lf;
+            }
+
+            if (effective_filter) {
+                if (apply_filter(ifaces[0].handle, "file",
+                                 effective_filter) == -1) {
+                    cleanup_all();
+                    return 1;
+                }
             }
         }
     } else {
@@ -727,12 +755,25 @@ int main(int argc, char *argv[])
                             ifaces[i].name, pcap_geterr(ifaces[i].handle));
             }
 
-            /* Apply BPF filter */
-            if (cfg.filter_expr) {
-                if (apply_filter(ifaces[i].handle, ifaces[i].name,
-                                 cfg.filter_expr) == -1) {
-                    cleanup_all();
-                    return 1;
+            /* Apply BPF filter (layer mode auto-filter + user filter) */
+            {
+                char layer_fbuf[512];
+                const char *effective_filter = cfg.filter_expr;
+
+                if (cfg.layer_mode) {
+                    const char *lf = layer_build_filter(
+                        cfg.layer_mode, cfg.filter_expr,
+                        layer_fbuf, sizeof(layer_fbuf));
+                    if (lf)
+                        effective_filter = lf;
+                }
+
+                if (effective_filter) {
+                    if (apply_filter(ifaces[i].handle, ifaces[i].name,
+                                     effective_filter) == -1) {
+                        cleanup_all();
+                        return 1;
+                    }
                 }
             }
         }
@@ -806,6 +847,8 @@ int main(int argc, char *argv[])
                    i < iface_count - 1 ? "," : "");
         printf(" (direction: %s)", dir_str);
     }
+    if (cfg.layer_mode)
+        printf(" [L%d detail]", cfg.layer_mode);
     if (cfg.filter_expr)
         printf(" [filter: %s]", cfg.filter_expr);
     if (cfg.no_promisc)

--- a/pkt_monitor.h
+++ b/pkt_monitor.h
@@ -46,6 +46,7 @@ typedef struct {
     int         interval_ms;    /* -n: output interval in ms (default 1000) */
     const char *write_file;     /* -w: pcap output file */
     const char *read_file;      /* -r: pcap input file */
+    int         layer_mode;     /* -L: 0=all, 2/3/4=layer detail */
 } monitor_config_t;
 
 static inline void get_time_str(char *buf, size_t len)


### PR DESCRIPTION
## Summary

Closes #21

- Add `-L 2|3|4` flag to select layer-specific packet detail mode (L2=ARP, L3=IP/ICMP, L4=TCP/UDP)
- Auto-apply BPF filters at kernel level for efficient filtering per layer
- Combine with user `-f` filter via AND when both are specified
- Add `layer_detail.h` / `layer_detail.c` with ring buffer infrastructure for per-packet detail display
- Validate mutually exclusive options (`-L` cannot combine with `-j`/`-c`)

## Changes

| File | Change |
|------|--------|
| `pkt_monitor.h` | Add `layer_mode` field to `monitor_config_t` |
| `pkt_monitor.c` | Add `-L` option parsing, BPF filter auto-setup, banner display |
| `layer_detail.h` | New: ring buffer types and filter builder API |
| `layer_detail.c` | New: ring buffer ops (`push`/`get`/`clear`) and `layer_build_filter()` |
| `Makefile` | Add `layer_detail.c` to build |
| `CLAUDE.md` | Document new files and design decisions |

## Test plan

- [x] Build passes with `-Wall -Wextra -Werror` (no warnings)
- [x] `-L 5` / `-L 1` → error message
- [x] `-L 4 -j` → mutually exclusive error
- [x] `-h` shows new `-L` option
- [ ] `sudo ./pkt_monitor -L 2` applies `arp` BPF filter
- [ ] `sudo ./pkt_monitor -L 4 -f "host 8.8.8.8"` combines filters as `(host 8.8.8.8) and (tcp or udp)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)