### PR TITLE
feat: layer detail mode, name resolution visualization, Prometheus exporter (#22-26, #17)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,33 +35,43 @@ sudo ./pkt_monitor [-d device] [-i|-o] [-u] [-h]
 
 ### Files
 
-- `pkt_monitor.h`: shared types (`packet_counter_t`, `monitor_config_t`) and constants
-- `pkt_monitor.c`: main(), capture logic, text mode output, TUI mode loop
-- `layer_detail.h` / `layer_detail.c`: layer detail mode ring buffer and BPF filter builder
+- `pkt_monitor.h`: shared types (`packet_counter_t`, `monitor_config_t`, `port_service_name()`) and constants
+- `pkt_monitor.c`: main(), capture logic, text mode output, TUI mode loop, layer detail packet parsing
+- `layer_detail.h` / `layer_detail.c`: ring buffer, layer counters, ARP/DNS resolver trackers, BPF filter builders
+- `dns_parse.h` / `dns_parse.c`: DNS packet parser (header, question, answer sections with compression pointer support)
+- `prometheus.h` / `prometheus.c`: Prometheus metrics exporter (background thread HTTP server, no external deps)
 - `tui.h` / `tui.c`: ncurses TUI rendering (compiled only when ncurses is available)
 
 ### Key sections in pkt_monitor.c
 
 - `packet_handler()`: pcap callback, parses Ethernet frames and updates per-second counters
-- `alarm_handler()`: SIGALRM handler for text mode, fires every second via `setitimer`
-- `run_tui()`: TUI mode main loop using `pcap_dispatch()` (non-blocking) + ncurses
+- `detail_packet_handler()`: layer detail / resolve mode packet parsing (ARP, IP/ICMP, TCP/UDP, DNS)
+- `run_layer_detail()`: text mode loop for -L and -R modes (ring buffer flush + counter display)
+- `run_tui_detail()`: TUI mode loop for -L and -R modes
+- `run_tui()`: TUI mode main loop for standard capture mode
 - `accumulate_totals()`: adds per-second counters to cumulative totals
-- `main()`: argument parsing, pcap setup, mode dispatch (text vs TUI)
+- `main()`: argument parsing, pcap setup, mode dispatch (text vs TUI vs detail)
 
 ### Key sections in tui.c
 
 - `tui_init()`: ncurses setup, color pairs, terminal size check
 - `tui_update()`: draws header, protocol table with bar graphs, footer
+- `tui_update_detail()`: draws layer detail counters + ring buffer for -L/-R modes
 - `tui_handle_input()`: non-blocking key input (q=quit, p=pause, r=reset)
 - `tui_cleanup()`: ncurses teardown
 
 ### Design decisions
 
-- Text mode uses `pcap_loop()` (blocking) + SIGALRM timer
+- Text mode uses `pcap_dispatch()` (non-blocking polling) + `now_ms()` timer
 - TUI mode uses `pcap_dispatch()` (non-blocking, ~100ms timeout) + `gettimeofday()` timer
 - SIGALRM is disabled in TUI mode to avoid ncurses corruption
 - `#ifdef HAS_NCURSES` guards all ncurses code for conditional compilation
 - `-L` layer mode auto-applies BPF filters (L2=arp, L3=ip/ip6/icmp, L4=tcp/udp) and combines with user `-f` filter via AND
+- `-R` resolve mode auto-applies BPF filters (arp for ARP, udp port 53 for DNS)
+- `--prometheus :PORT` starts a background thread HTTP server serving `/metrics` in Prometheus text format
+- ARP resolver tracks Request→Reply pairs with 3s timeout; DNS resolver tracks Query→Response by txid with 5s timeout
+- `detail_packet_handler()` is called from `packet_handler()` when layer_mode or resolve_mode is active
+- Layer counters (layer2/3/4_counter_t) and resolver trackers are stored in global `detail_ctx_t`
 
 ## Important Notes
 
@@ -69,5 +79,6 @@ sudo ./pkt_monitor [-d device] [-i|-o] [-u] [-h]
 - ICMP and TCP/UDP counters are only incremented for IPv4; IPv6 transport protocols are not broken down further
 - `INTVAL` (10) controls how often the header line is reprinted (text mode)
 - `SNAP_LEN` (1600) is the capture snapshot length in bytes
-- The `alldevs` memory from `pcap_findalldevs` is intentionally not freed because the `device` pointer references it
+- The `alldevs` memory from `pcap_findalldevs` is freed after copying the device name
 - TUI requires minimum terminal size of 60x15
+- `-L` and `-R` are mutually exclusive; neither can combine with `-j` or `-c`

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 PACKAGE = pkt_monitor
 CC      = cc
 CFLAGS  = -O2 -g -Wall -Wextra -Werror
-LDFLAGS = -lpcap
+LDFLAGS = -lpcap -lpthread
 PREFIX ?= /usr/local
 
-SRCS = pkt_monitor.c output.c stats.c layer_detail.c
+SRCS = pkt_monitor.c output.c stats.c layer_detail.c dns_parse.c prometheus.c
 OBJS = $(SRCS:.c=.o)
 
 # Auto-detect ncurses
@@ -40,6 +40,12 @@ stats.o: stats.c stats.h
 	$(CC) $(CFLAGS) -c $<
 
 layer_detail.o: layer_detail.c layer_detail.h
+	$(CC) $(CFLAGS) -c $<
+
+dns_parse.o: dns_parse.c dns_parse.h
+	$(CC) $(CFLAGS) -c $<
+
+prometheus.o: prometheus.c prometheus.h pkt_monitor.h
 	$(CC) $(CFLAGS) -c $<
 
 clean:

--- a/dns_parse.c
+++ b/dns_parse.c
@@ -1,0 +1,215 @@
+/*
+ * dns_parse.c - DNS packet parser
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <arpa/inet.h>
+
+#include "dns_parse.h"
+
+/* ---- name tables ------------------------------------------------------ */
+
+const char *dns_type_name(uint16_t type)
+{
+    switch (type) {
+    case 1:   return "A";
+    case 2:   return "NS";
+    case 5:   return "CNAME";
+    case 6:   return "SOA";
+    case 12:  return "PTR";
+    case 15:  return "MX";
+    case 16:  return "TXT";
+    case 28:  return "AAAA";
+    case 33:  return "SRV";
+    case 41:  return "OPT";
+    case 65:  return "HTTPS";
+    case 255: return "ANY";
+    default:  return NULL;
+    }
+}
+
+const char *dns_rcode_name(int rcode)
+{
+    switch (rcode) {
+    case 0: return "NOERROR";
+    case 1: return "FORMERR";
+    case 2: return "SERVFAIL";
+    case 3: return "NXDOMAIN";
+    case 4: return "NOTIMP";
+    case 5: return "REFUSED";
+    default: return "UNKNOWN";
+    }
+}
+
+/* ---- DNS name decompression ------------------------------------------- */
+
+/*
+ * Decode a DNS name with compression pointer support.
+ * pkt: start of DNS packet, pkt_len: total packet length.
+ * offset: current read position (updated on return).
+ * out: output buffer, out_len: output buffer size.
+ * Returns 0 on success, -1 on error.
+ */
+static int dns_decode_name(const uint8_t *pkt, size_t pkt_len,
+                           size_t *offset, char *out, size_t out_len)
+{
+    size_t pos = *offset;
+    size_t out_pos = 0;
+    int jumped = 0;
+    size_t end_pos = 0;
+    int loop_guard = 0;
+
+    while (pos < pkt_len) {
+        uint8_t label_len = pkt[pos];
+
+        if (loop_guard++ > 128) return -1;  /* circular reference */
+
+        if (label_len == 0) {
+            pos++;
+            if (!jumped) end_pos = pos;
+            break;
+        }
+
+        if ((label_len & 0xC0) == 0xC0) {
+            /* compression pointer */
+            if (pos + 1 >= pkt_len) return -1;
+            size_t ptr = ((size_t)(label_len & 0x3F) << 8) | pkt[pos + 1];
+            if (ptr >= pkt_len) return -1;
+            if (!jumped) end_pos = pos + 2;
+            pos = ptr;
+            jumped = 1;
+            continue;
+        }
+
+        pos++;
+        if (pos + label_len > pkt_len) return -1;
+
+        if (out_pos > 0 && out_pos < out_len - 1)
+            out[out_pos++] = '.';
+
+        size_t copy_len = label_len;
+        if (out_pos + copy_len >= out_len - 1)
+            copy_len = out_len - 1 - out_pos;
+        memcpy(out + out_pos, pkt + pos, copy_len);
+        out_pos += copy_len;
+        pos += label_len;
+    }
+
+    out[out_pos] = '\0';
+    *offset = jumped ? end_pos : pos;
+    return 0;
+}
+
+/* ---- main parser ------------------------------------------------------ */
+
+int dns_parse(const uint8_t *data, size_t len, dns_parsed_t *out)
+{
+    size_t offset;
+    int i;
+
+    memset(out, 0, sizeof(*out));
+
+    if (len < 12) return -1;
+
+    /* Parse header */
+    out->hdr.id      = ntohs(*(const uint16_t *)(data + 0));
+    out->hdr.flags   = ntohs(*(const uint16_t *)(data + 2));
+    out->hdr.qdcount = ntohs(*(const uint16_t *)(data + 4));
+    out->hdr.ancount = ntohs(*(const uint16_t *)(data + 6));
+    out->hdr.nscount = ntohs(*(const uint16_t *)(data + 8));
+    out->hdr.arcount = ntohs(*(const uint16_t *)(data + 10));
+
+    out->is_response = (out->hdr.flags >> 15) & 1;
+    out->rcode       = out->hdr.flags & 0x0F;
+
+    offset = 12;
+
+    /* Parse question section (only first question) */
+    if (out->hdr.qdcount > 0) {
+        if (dns_decode_name(data, len, &offset, out->qname,
+                            sizeof(out->qname)) < 0)
+            return -1;
+        if (offset + 4 > len) return -1;
+        out->qtype  = ntohs(*(const uint16_t *)(data + offset));
+        out->qclass = ntohs(*(const uint16_t *)(data + offset + 2));
+        offset += 4;
+
+        /* skip remaining questions */
+        for (i = 1; i < (int)out->hdr.qdcount; i++) {
+            char skip[256];
+            if (dns_decode_name(data, len, &offset, skip, sizeof(skip)) < 0)
+                return -1;
+            if (offset + 4 > len) return -1;
+            offset += 4;
+        }
+    }
+
+    /* Parse answer section */
+    out->answer_count = 0;
+    for (i = 0; i < (int)out->hdr.ancount && offset < len; i++) {
+        char name[256];
+        uint16_t rtype, rclass, rdlen;
+        uint32_t ttl;
+
+        if (dns_decode_name(data, len, &offset, name, sizeof(name)) < 0)
+            break;
+        if (offset + 10 > len) break;
+
+        rtype  = ntohs(*(const uint16_t *)(data + offset));
+        rclass = ntohs(*(const uint16_t *)(data + offset + 2));
+        memcpy(&ttl, data + offset + 4, 4);
+        ttl = ntohl(ttl);
+        rdlen  = ntohs(*(const uint16_t *)(data + offset + 8));
+        offset += 10;
+
+        if (offset + rdlen > len) break;
+
+        if (out->answer_count < DNS_MAX_ANSWERS) {
+            dns_answer_t *a = &out->answers[out->answer_count];
+            snprintf(a->name, sizeof(a->name), "%s", name);
+            a->type   = rtype;
+            a->class_ = rclass;
+            a->ttl    = ttl;
+            a->rdata_str[0] = '\0';
+
+            /* Format rdata based on type */
+            if (rtype == 1 && rdlen == 4) {
+                /* A record */
+                struct in_addr addr;
+                memcpy(&addr, data + offset, 4);
+                inet_ntop(AF_INET, &addr, a->rdata_str,
+                          sizeof(a->rdata_str));
+            } else if (rtype == 28 && rdlen == 16) {
+                /* AAAA record */
+                struct in6_addr addr6;
+                memcpy(&addr6, data + offset, 16);
+                inet_ntop(AF_INET6, &addr6, a->rdata_str,
+                          sizeof(a->rdata_str));
+            } else if (rtype == 5 || rtype == 2 || rtype == 12) {
+                /* CNAME, NS, PTR */
+                size_t rd_off = offset;
+                dns_decode_name(data, len, &rd_off,
+                                a->rdata_str, sizeof(a->rdata_str));
+            } else if (rtype == 15 && rdlen >= 3) {
+                /* MX: 2-byte preference + name */
+                uint16_t pref = ntohs(*(const uint16_t *)(data + offset));
+                size_t rd_off = offset + 2;
+                char mx_name[200];
+                if (dns_decode_name(data, len, &rd_off,
+                                    mx_name, sizeof(mx_name)) == 0)
+                    snprintf(a->rdata_str, sizeof(a->rdata_str),
+                             "%u %s", pref, mx_name);
+            } else {
+                snprintf(a->rdata_str, sizeof(a->rdata_str),
+                         "(%u bytes)", rdlen);
+            }
+
+            out->answer_count++;
+        }
+
+        offset += rdlen;
+    }
+
+    return 0;
+}

--- a/dns_parse.h
+++ b/dns_parse.h
@@ -1,0 +1,58 @@
+/*
+ * dns_parse.h - DNS packet parser for resolve mode
+ */
+
+#ifndef DNS_PARSE_H
+#define DNS_PARSE_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* DNS header (12 bytes) */
+typedef struct {
+    uint16_t id;
+    uint16_t flags;
+    uint16_t qdcount;
+    uint16_t ancount;
+    uint16_t nscount;
+    uint16_t arcount;
+} dns_header_t;
+
+/* Parsed DNS answer record */
+typedef struct {
+    char     name[256];
+    uint16_t type;
+    uint16_t class_;
+    uint32_t ttl;
+    char     rdata_str[256];  /* human-readable rdata */
+} dns_answer_t;
+
+#define DNS_MAX_ANSWERS 8
+
+/* Parsed DNS packet */
+typedef struct {
+    dns_header_t hdr;
+    char         qname[256];
+    uint16_t     qtype;
+    uint16_t     qclass;
+    int          is_response;
+    int          rcode;
+    int          answer_count;          /* actually parsed count */
+    dns_answer_t answers[DNS_MAX_ANSWERS];
+} dns_parsed_t;
+
+/*
+ * Parse a DNS packet starting from the DNS header.
+ * data: pointer to start of DNS header
+ * len:  bytes available
+ * Returns 0 on success, -1 on parse error.
+ */
+int dns_parse(const uint8_t *data, size_t len, dns_parsed_t *out);
+
+/* Lookup DNS record type name (A, AAAA, CNAME, etc.) */
+const char *dns_type_name(uint16_t type);
+
+/* Lookup DNS RCODE name (NOERROR, NXDOMAIN, etc.) */
+const char *dns_rcode_name(int rcode);
+
+#endif /* DNS_PARSE_H */

--- a/layer_detail.c
+++ b/layer_detail.c
@@ -1,5 +1,5 @@
 /*
- * layer_detail.c - Layer detail mode: ring buffer and display helpers
+ * layer_detail.c - Layer detail mode: ring buffer, resolver trackers, filters
  */
 
 #include <string.h>
@@ -7,6 +7,8 @@
 #include <sys/time.h>
 
 #include "layer_detail.h"
+
+/* ---- ring buffer ------------------------------------------------------ */
 
 void detail_ring_push(detail_ring_t *ring, const char *line)
 {
@@ -41,6 +43,8 @@ void detail_ring_clear(detail_ring_t *ring)
     ring->count = 0;
 }
 
+/* ---- BPF filter builders ---------------------------------------------- */
+
 const char *layer_build_filter(int layer_mode, const char *user_filter,
                                char *buf, size_t buflen)
 {
@@ -66,4 +70,164 @@ const char *layer_build_filter(int layer_mode, const char *user_filter,
         snprintf(buf, buflen, "%s", layer_filter);
 
     return buf;
+}
+
+const char *resolve_build_filter(int resolve_mode, const char *user_filter,
+                                 char *buf, size_t buflen)
+{
+    const char *base;
+
+    switch (resolve_mode) {
+    case 'a':
+        base = "arp";
+        break;
+    case 'd':
+        base = "udp port 53";
+        break;
+    default:
+        return NULL;
+    }
+
+    if (user_filter)
+        snprintf(buf, buflen, "(%s) and (%s)", user_filter, base);
+    else
+        snprintf(buf, buflen, "%s", base);
+
+    return buf;
+}
+
+/* ---- timeval helpers -------------------------------------------------- */
+
+static double tv_diff_ms(const struct timeval *end, const struct timeval *start)
+{
+    double sec  = (double)(end->tv_sec  - start->tv_sec);
+    double usec = (double)(end->tv_usec - start->tv_usec);
+    return sec * 1000.0 + usec / 1000.0;
+}
+
+/* ---- ARP resolver ----------------------------------------------------- */
+
+void arp_resolver_request(arp_resolver_t *r, uint32_t target_ip,
+                          const struct timeval *ts)
+{
+    int i;
+
+    r->counter.requests++;
+
+    /* check for existing pending entry for this target */
+    for (i = 0; i < r->pending_count; i++) {
+        if (r->pending[i].target_ip == target_ip && !r->pending[i].answered) {
+            r->pending[i].request_time = *ts;
+            return;
+        }
+    }
+
+    /* add new pending entry */
+    if (r->pending_count < ARP_PENDING_MAX) {
+        arp_pending_t *p = &r->pending[r->pending_count++];
+        p->target_ip    = target_ip;
+        p->request_time = *ts;
+        p->answered     = 0;
+    }
+}
+
+double arp_resolver_reply(arp_resolver_t *r, uint32_t target_ip,
+                          const struct timeval *ts)
+{
+    int i;
+
+    r->counter.replies++;
+
+    for (i = 0; i < r->pending_count; i++) {
+        if (r->pending[i].target_ip == target_ip && !r->pending[i].answered) {
+            r->pending[i].answered = 1;
+            r->counter.matched++;
+            return tv_diff_ms(ts, &r->pending[i].request_time);
+        }
+    }
+
+    return -1.0;
+}
+
+void arp_resolver_expire(arp_resolver_t *r, const struct timeval *now)
+{
+    int i, j;
+
+    for (i = 0; i < r->pending_count; ) {
+        arp_pending_t *p = &r->pending[i];
+        if (p->answered || tv_diff_ms(now, &p->request_time) > ARP_TIMEOUT_MS) {
+            if (!p->answered)
+                r->counter.timeouts++;
+            /* remove by shifting */
+            for (j = i; j < r->pending_count - 1; j++)
+                r->pending[j] = r->pending[j + 1];
+            r->pending_count--;
+        } else {
+            i++;
+        }
+    }
+}
+
+/* ---- DNS resolver ----------------------------------------------------- */
+
+void dns_resolver_query(dns_resolver_t *r, uint16_t txid, const char *qname,
+                        const struct timeval *ts)
+{
+    int i;
+
+    r->counter.queries++;
+
+    /* check for existing pending entry with same txid */
+    for (i = 0; i < r->pending_count; i++) {
+        if (r->pending[i].txid == txid && !r->pending[i].answered) {
+            r->pending[i].query_time = *ts;
+            snprintf(r->pending[i].qname, sizeof(r->pending[i].qname),
+                     "%s", qname);
+            return;
+        }
+    }
+
+    if (r->pending_count < DNS_PENDING_MAX) {
+        dns_pending_t *p = &r->pending[r->pending_count++];
+        p->txid      = txid;
+        p->query_time = *ts;
+        p->answered  = 0;
+        snprintf(p->qname, sizeof(p->qname), "%s", qname);
+    }
+}
+
+double dns_resolver_response(dns_resolver_t *r, uint16_t txid,
+                             const struct timeval *ts)
+{
+    int i;
+
+    r->counter.responses++;
+
+    for (i = 0; i < r->pending_count; i++) {
+        if (r->pending[i].txid == txid && !r->pending[i].answered) {
+            r->pending[i].answered = 1;
+            r->counter.matched++;
+            return tv_diff_ms(ts, &r->pending[i].query_time);
+        }
+    }
+
+    return -1.0;
+}
+
+void dns_resolver_expire(dns_resolver_t *r, const struct timeval *now)
+{
+    int i, j;
+
+    for (i = 0; i < r->pending_count; ) {
+        dns_pending_t *p = &r->pending[i];
+        if (p->answered || tv_diff_ms(now, &p->query_time) > DNS_TIMEOUT_MS) {
+            if (!p->answered)
+                r->counter.timeouts++;
+            for (j = i; j < r->pending_count - 1; j++)
+                r->pending[j] = r->pending[j + 1];
+            r->pending_count--;
+        } else {
+            i++;
+        }
+    }
 }

--- a/layer_detail.h
+++ b/layer_detail.h
@@ -1,14 +1,17 @@
 /*
- * layer_detail.h - Layer detail mode: ring buffer and display helpers
+ * layer_detail.h - Layer detail mode: ring buffer, counters, and display helpers
  */
 
 #ifndef LAYER_DETAIL_H
 #define LAYER_DETAIL_H
 
+#include <stdint.h>
 #include <sys/time.h>
 
 #define DETAIL_RING_SIZE 64
 #define DETAIL_LINE_LEN  256
+
+/* ---- ring buffer ------------------------------------------------------ */
 
 typedef struct {
     char           line[DETAIL_LINE_LEN];  /* formatted display line */
@@ -21,22 +24,97 @@ typedef struct {
     int count;  /* entries stored (max DETAIL_RING_SIZE) */
 } detail_ring_t;
 
-/*
- * Append a formatted line to the ring buffer.
- * Older entries are overwritten when the buffer is full.
- */
-void detail_ring_push(detail_ring_t *ring, const char *line);
+void                   detail_ring_push(detail_ring_t *ring, const char *line);
+const detail_entry_t  *detail_ring_get(const detail_ring_t *ring, int idx);
+void                   detail_ring_clear(detail_ring_t *ring);
 
-/*
- * Get entry at logical index (0 = oldest).
- * Returns NULL if idx >= count.
- */
-const detail_entry_t *detail_ring_get(const detail_ring_t *ring, int idx);
+/* ---- layer counters --------------------------------------------------- */
 
-/*
- * Clear all entries.
- */
-void detail_ring_clear(detail_ring_t *ring);
+typedef struct {
+    uint32_t request;
+    uint32_t reply;
+    uint32_t other;
+} layer2_counter_t;
+
+typedef struct {
+    uint32_t ipv4;
+    uint32_t ipv6;
+    uint32_t icmp;
+} layer3_counter_t;
+
+typedef struct {
+    uint32_t tcp_total;
+    uint32_t udp_total;
+    uint32_t tcp_syn;
+    uint32_t tcp_synack;
+    uint32_t tcp_ack;
+    uint32_t tcp_fin;
+    uint32_t tcp_rst;
+    uint32_t tcp_psh;
+} layer4_counter_t;
+
+/* ---- ARP resolver tracker --------------------------------------------- */
+
+#define ARP_PENDING_MAX  128
+#define ARP_TIMEOUT_MS   3000
+
+typedef struct {
+    uint32_t       target_ip;       /* network byte order */
+    struct timeval request_time;
+    int            answered;
+} arp_pending_t;
+
+typedef struct {
+    uint32_t requests;
+    uint32_t replies;
+    uint32_t matched;       /* request→reply paired */
+    uint32_t timeouts;
+    uint32_t gratuitous;
+} arp_resolve_counter_t;
+
+typedef struct {
+    arp_pending_t         pending[ARP_PENDING_MAX];
+    int                   pending_count;
+    arp_resolve_counter_t counter;
+} arp_resolver_t;
+
+/* ---- DNS resolver tracker --------------------------------------------- */
+
+#define DNS_PENDING_MAX  256
+#define DNS_TIMEOUT_MS   5000
+
+typedef struct {
+    uint16_t       txid;
+    char           qname[128];
+    struct timeval query_time;
+    int            answered;
+} dns_pending_t;
+
+typedef struct {
+    uint32_t queries;
+    uint32_t responses;
+    uint32_t matched;
+    uint32_t timeouts;
+    uint32_t nxdomain;
+    uint32_t errors;        /* SERVFAIL, REFUSED, etc. */
+} dns_resolve_counter_t;
+
+typedef struct {
+    dns_pending_t          pending[DNS_PENDING_MAX];
+    int                    pending_count;
+    dns_resolve_counter_t  counter;
+} dns_resolver_t;
+
+/* ---- unified detail context ------------------------------------------- */
+
+typedef struct {
+    detail_ring_t      ring;
+    layer2_counter_t   l2;
+    layer3_counter_t   l3;
+    layer4_counter_t   l4;
+    arp_resolver_t     arp_res;
+    dns_resolver_t     dns_res;
+} detail_ctx_t;
 
 /*
  * Build the auto BPF filter string for a given layer mode.
@@ -46,5 +124,31 @@ void detail_ring_clear(detail_ring_t *ring);
  */
 const char *layer_build_filter(int layer_mode, const char *user_filter,
                                char *buf, size_t buflen);
+
+/*
+ * Build the BPF filter for resolve mode.
+ * resolve_mode: 'a' (arp) or 'd' (dns).
+ */
+const char *resolve_build_filter(int resolve_mode, const char *user_filter,
+                                 char *buf, size_t buflen);
+
+/*
+ * ARP resolver: record a request, match a reply.
+ * Returns elapsed_ms >= 0 on matched reply, -1 if unmatched.
+ */
+void arp_resolver_request(arp_resolver_t *r, uint32_t target_ip,
+                          const struct timeval *ts);
+double arp_resolver_reply(arp_resolver_t *r, uint32_t target_ip,
+                          const struct timeval *ts);
+void arp_resolver_expire(arp_resolver_t *r, const struct timeval *now);
+
+/*
+ * DNS resolver: record a query, match a response.
+ */
+void dns_resolver_query(dns_resolver_t *r, uint16_t txid, const char *qname,
+                        const struct timeval *ts);
+double dns_resolver_response(dns_resolver_t *r, uint16_t txid,
+                             const struct timeval *ts);
+void dns_resolver_expire(dns_resolver_t *r, const struct timeval *now);
 
 #endif /* LAYER_DETAIL_H */

--- a/pkt_monitor.c
+++ b/pkt_monitor.c
@@ -16,6 +16,7 @@
 #include <unistd.h>
 #include <inttypes.h>
 #include <sys/time.h>
+#include <getopt.h>
 
 #include <pcap/pcap.h>
 
@@ -30,10 +31,15 @@
 #include <netinet/ether.h>
 #endif
 
+#include <net/if_arp.h>
+#include <arpa/inet.h>
+
 #include "pkt_monitor.h"
 #include "output.h"
 #include "stats.h"
 #include "layer_detail.h"
+#include "dns_parse.h"
+#include "prometheus.h"
 
 #ifdef HAS_NCURSES
 #include "tui.h"
@@ -46,6 +52,8 @@ static int iface_count;
 static volatile sig_atomic_t running = 1;
 static flow_stats_t *g_flow_stats;  /* non-NULL when -T is active */
 static pcap_dumper_t *g_dumper;     /* non-NULL when -w is active */
+static detail_ctx_t g_detail;       /* layer detail / resolve mode context */
+static const monitor_config_t *g_cfg; /* pointer for packet_handler access */
 
 /*
  * Accumulate per-second counters into totals for one interface.
@@ -86,6 +94,10 @@ static void aggregate_counters(packet_counter_t *agg, int use_total)
     }
 }
 
+/* Forward declaration for detail mode handler */
+static void detail_packet_handler(const struct pcap_pkthdr *header,
+                                  const u_char *packet);
+
 /*
  * pcap callback: parse each captured packet and update counters.
  * The user pointer points to the iface_ctx_t's pkt_cnt.
@@ -103,6 +115,10 @@ static void packet_handler(u_char *user, const struct pcap_pkthdr *header,
 
     if (g_dumper)
         pcap_dump((u_char *)g_dumper, header, packet);
+
+    /* Dispatch to detail handler if layer/resolve mode is active */
+    if (g_cfg && (g_cfg->layer_mode || g_cfg->resolve_mode))
+        detail_packet_handler(header, packet);
 
     cnt->all++;
     cnt->bytes += header->len;
@@ -184,6 +200,486 @@ static void packet_handler(u_char *user, const struct pcap_pkthdr *header,
     }
 }
 
+/* ---- layer detail / resolve mode packet processing -------------------- */
+
+static const char *icmp_type_name(uint8_t type)
+{
+    switch (type) {
+    case 0:  return "Echo Reply";
+    case 3:  return "Dest Unreachable";
+    case 4:  return "Source Quench";
+    case 5:  return "Redirect";
+    case 8:  return "Echo Request";
+    case 9:  return "Router Advert";
+    case 10: return "Router Solicit";
+    case 11: return "Time Exceeded";
+    case 13: return "Timestamp";
+    case 14: return "Timestamp Reply";
+    default: return "Unknown";
+    }
+}
+
+static void tcp_flags_str(uint8_t flags, char *buf, size_t len)
+{
+    size_t pos = 0;
+
+    buf[0] = '\0';
+    if (pos < len - 1) buf[pos++] = '[';
+
+#define APPEND_FLAG(mask, name) do { \
+    if ((flags & (mask)) && pos < len - 4) { \
+        if (pos > 1) buf[pos++] = ','; \
+        const char *s = (name); \
+        while (*s && pos < len - 2) buf[pos++] = *s++; \
+    } \
+} while (0)
+
+    APPEND_FLAG(0x02, "SYN");
+    APPEND_FLAG(0x10, "ACK");
+    APPEND_FLAG(0x01, "FIN");
+    APPEND_FLAG(0x04, "RST");
+    APPEND_FLAG(0x08, "PSH");
+    APPEND_FLAG(0x20, "URG");
+#undef APPEND_FLAG
+
+    if (pos < len - 1) buf[pos++] = ']';
+    buf[pos] = '\0';
+}
+
+static const char *ip_proto_name(uint8_t proto)
+{
+    switch (proto) {
+    case IPPROTO_ICMP: return "ICMP";
+    case IPPROTO_TCP:  return "TCP";
+    case IPPROTO_UDP:  return "UDP";
+    case 2:            return "IGMP";
+    case 47:           return "GRE";
+    case 50:           return "ESP";
+    case 51:           return "AH";
+    case 89:           return "OSPF";
+    default:           return "Other";
+    }
+}
+
+static const char *ipv6_nxt_name(uint8_t nxt)
+{
+    switch (nxt) {
+    case IPPROTO_TCP:  return "TCP";
+    case IPPROTO_UDP:  return "UDP";
+    case 0:            return "HopByHop";
+    case 43:           return "Routing";
+    case 44:           return "Fragment";
+    case 58:           return "ICMPv6";
+    case 59:           return "NoNext";
+    case 60:           return "DestOpts";
+    default:           return "Other";
+    }
+}
+
+/*
+ * Layer-detail aware packet handler.
+ * Called from packet_handler when layer_mode or resolve_mode is active.
+ */
+static void detail_packet_handler(const struct pcap_pkthdr *header,
+                                  const u_char *packet)
+{
+    const struct ether_header *eth;
+    uint16_t ether_type;
+    char line[DETAIL_LINE_LEN];
+    char timebuf[16];
+
+    if (header->caplen < sizeof(struct ether_header))
+        return;
+
+    eth = (const struct ether_header *)packet;
+    ether_type = ntohs(eth->ether_type);
+
+    get_time_str(timebuf, sizeof(timebuf));
+
+    /* -R arp mode */
+    if (g_cfg->resolve_mode == 'a') {
+        if (ether_type != ETHERTYPE_ARP) return;
+        if (header->caplen < 42) return;  /* Ethernet 14 + ARP 28 */
+
+        const uint8_t *arp_raw = packet + sizeof(struct ether_header);
+        uint16_t op = ntohs(*(const uint16_t *)(arp_raw + 6));
+        /* sender: arp_raw+8 (6B MAC) + arp_raw+14 (4B IP) */
+        /* target: arp_raw+18 (6B MAC) + arp_raw+24 (4B IP) */
+        uint32_t sender_ip, target_ip;
+        memcpy(&sender_ip, arp_raw + 14, 4);
+        memcpy(&target_ip, arp_raw + 24, 4);
+
+        char src_str[INET_ADDRSTRLEN], dst_str[INET_ADDRSTRLEN];
+        inet_ntop(AF_INET, &sender_ip, src_str, sizeof(src_str));
+        inet_ntop(AF_INET, &target_ip, dst_str, sizeof(dst_str));
+
+        int is_gratuitous = (sender_ip == target_ip);
+
+        if (op == 1) { /* ARP Request */
+            arp_resolver_request(&g_detail.arp_res, target_ip, &header->ts);
+            if (is_gratuitous) {
+                g_detail.arp_res.counter.gratuitous++;
+                snprintf(line, sizeof(line),
+                         "%s  GRAT  %s (gratuitous ARP)", timebuf, src_str);
+            } else {
+                snprintf(line, sizeof(line),
+                         "%s  REQ   who-has %s? tell %s",
+                         timebuf, dst_str, src_str);
+            }
+        } else if (op == 2) { /* ARP Reply */
+            double ms = arp_resolver_reply(&g_detail.arp_res, sender_ip,
+                                           &header->ts);
+            if (ms >= 0) {
+                snprintf(line, sizeof(line),
+                         "%s  REPLY %s is-at %02x:%02x:%02x:%02x:%02x:%02x (%.1fms)",
+                         timebuf, src_str,
+                         packet[22], packet[23], packet[24],
+                         packet[25], packet[26], packet[27], ms);
+            } else {
+                snprintf(line, sizeof(line),
+                         "%s  REPLY %s is-at %02x:%02x:%02x:%02x:%02x:%02x",
+                         timebuf, src_str,
+                         packet[22], packet[23], packet[24],
+                         packet[25], packet[26], packet[27]);
+            }
+        } else {
+            snprintf(line, sizeof(line),
+                     "%s  ARP op=%u %s -> %s", timebuf, op, src_str, dst_str);
+        }
+
+        detail_ring_push(&g_detail.ring, line);
+        return;
+    }
+
+    /* -R dns mode */
+    if (g_cfg->resolve_mode == 'd') {
+        /* Must be IP + UDP + port 53 */
+        if (ether_type != ETHERTYPE_IP) return;
+        if (header->caplen < sizeof(struct ether_header) + 20) return;
+
+        const struct ip *iph = (const struct ip *)
+            (packet + sizeof(struct ether_header));
+        if (iph->ip_p != IPPROTO_UDP) return;
+
+        unsigned int ip_hlen = (unsigned int)iph->ip_hl * 4;
+        size_t udp_off = sizeof(struct ether_header) + ip_hlen;
+        if (header->caplen < udp_off + 8) return;
+
+        const struct udphdr *uh = (const struct udphdr *)(packet + udp_off);
+        uint16_t sport = ntohs(uh->uh_sport);
+        uint16_t dport = ntohs(uh->uh_dport);
+        if (sport != 53 && dport != 53) return;
+
+        size_t dns_off = udp_off + 8;
+        size_t dns_len = header->caplen - dns_off;
+        if (dns_len < 12) return;
+
+        dns_parsed_t dns;
+        if (dns_parse(packet + dns_off, dns_len, &dns) < 0) return;
+
+        if (!dns.is_response) {
+            /* Query */
+            const char *tname = dns_type_name(dns.qtype);
+            dns_resolver_query(&g_detail.dns_res, dns.hdr.id,
+                               dns.qname, &header->ts);
+            if (tname)
+                snprintf(line, sizeof(line), "%s  Q  %s %s",
+                         timebuf, tname, dns.qname);
+            else
+                snprintf(line, sizeof(line), "%s  Q  type%u %s",
+                         timebuf, dns.qtype, dns.qname);
+        } else {
+            /* Response */
+            double ms = dns_resolver_response(&g_detail.dns_res, dns.hdr.id,
+                                              &header->ts);
+            const char *rc = dns_rcode_name(dns.rcode);
+
+            if (dns.rcode == 3)
+                g_detail.dns_res.counter.nxdomain++;
+            else if (dns.rcode != 0)
+                g_detail.dns_res.counter.errors++;
+
+            if (dns.answer_count > 0) {
+                const char *tname = dns_type_name(dns.answers[0].type);
+                if (ms >= 0)
+                    snprintf(line, sizeof(line),
+                             "%s  R  %s %s -> %s %s (%.1fms)",
+                             timebuf, rc, dns.qname,
+                             tname ? tname : "?",
+                             dns.answers[0].rdata_str, ms);
+                else
+                    snprintf(line, sizeof(line),
+                             "%s  R  %s %s -> %s %s",
+                             timebuf, rc, dns.qname,
+                             tname ? tname : "?",
+                             dns.answers[0].rdata_str);
+            } else {
+                if (ms >= 0)
+                    snprintf(line, sizeof(line),
+                             "%s  R  %s %s (no answers, %.1fms)",
+                             timebuf, rc, dns.qname, ms);
+                else
+                    snprintf(line, sizeof(line),
+                             "%s  R  %s %s (no answers)",
+                             timebuf, rc, dns.qname);
+            }
+        }
+
+        detail_ring_push(&g_detail.ring, line);
+        return;
+    }
+
+    /* -L 2 ARP detail */
+    if (g_cfg->layer_mode == 2) {
+        if (ether_type != ETHERTYPE_ARP) return;
+        if (header->caplen < 42) return;
+
+        const uint8_t *arp_raw = packet + sizeof(struct ether_header);
+        uint16_t op = ntohs(*(const uint16_t *)(arp_raw + 6));
+        uint32_t sender_ip, target_ip;
+        memcpy(&sender_ip, arp_raw + 14, 4);
+        memcpy(&target_ip, arp_raw + 24, 4);
+
+        char src_str[INET_ADDRSTRLEN], dst_str[INET_ADDRSTRLEN];
+        inet_ntop(AF_INET, &sender_ip, src_str, sizeof(src_str));
+        inet_ntop(AF_INET, &target_ip, dst_str, sizeof(dst_str));
+
+        if (op == 1) {
+            g_detail.l2.request++;
+            snprintf(line, sizeof(line),
+                     "%s  REQ   who-has %s? tell %s",
+                     timebuf, dst_str, src_str);
+        } else if (op == 2) {
+            g_detail.l2.reply++;
+            snprintf(line, sizeof(line),
+                     "%s  REPLY %s is-at %02x:%02x:%02x:%02x:%02x:%02x",
+                     timebuf, src_str,
+                     packet[22], packet[23], packet[24],
+                     packet[25], packet[26], packet[27]);
+        } else {
+            g_detail.l2.other++;
+            snprintf(line, sizeof(line),
+                     "%s  ARP op=%u %s -> %s", timebuf, op, src_str, dst_str);
+        }
+
+        detail_ring_push(&g_detail.ring, line);
+        return;
+    }
+
+    /* -L 3 IP/IPv6/ICMP detail */
+    if (g_cfg->layer_mode == 3) {
+        if (ether_type == ETHERTYPE_IP) {
+            if (header->caplen < sizeof(struct ether_header) + sizeof(struct ip))
+                return;
+            const struct ip *iph = (const struct ip *)
+                (packet + sizeof(struct ether_header));
+
+            char src_str[INET_ADDRSTRLEN], dst_str[INET_ADDRSTRLEN];
+            inet_ntop(AF_INET, &iph->ip_src, src_str, sizeof(src_str));
+            inet_ntop(AF_INET, &iph->ip_dst, dst_str, sizeof(dst_str));
+
+            g_detail.l3.ipv4++;
+
+            if (iph->ip_p == IPPROTO_ICMP) {
+                g_detail.l3.icmp++;
+                unsigned int ip_hlen = (unsigned int)iph->ip_hl * 4;
+                if (header->caplen >= sizeof(struct ether_header) + ip_hlen + 4) {
+                    const uint8_t *icmp = packet + sizeof(struct ether_header) + ip_hlen;
+                    uint8_t icmp_type = icmp[0];
+                    uint8_t icmp_code = icmp[1];
+                    snprintf(line, sizeof(line),
+                             "%s  ICMP  %s -> %s  %s (type=%u code=%u)",
+                             timebuf, src_str, dst_str,
+                             icmp_type_name(icmp_type), icmp_type, icmp_code);
+                } else {
+                    snprintf(line, sizeof(line),
+                             "%s  ICMP  %s -> %s  (truncated)",
+                             timebuf, src_str, dst_str);
+                }
+            } else {
+                snprintf(line, sizeof(line),
+                         "%s  IPv4  %s -> %s  proto=%s TTL=%u %uB",
+                         timebuf, src_str, dst_str,
+                         ip_proto_name(iph->ip_p),
+                         iph->ip_ttl, ntohs(iph->ip_len));
+            }
+        } else if (ether_type == ETHERTYPE_IPV6) {
+            if (header->caplen < sizeof(struct ether_header) + sizeof(struct ip6_hdr))
+                return;
+            const struct ip6_hdr *ip6 = (const struct ip6_hdr *)
+                (packet + sizeof(struct ether_header));
+
+            char src_str[INET6_ADDRSTRLEN], dst_str[INET6_ADDRSTRLEN];
+            inet_ntop(AF_INET6, &ip6->ip6_src, src_str, sizeof(src_str));
+            inet_ntop(AF_INET6, &ip6->ip6_dst, dst_str, sizeof(dst_str));
+
+            g_detail.l3.ipv6++;
+
+            snprintf(line, sizeof(line),
+                     "%s  IPv6  %s -> %s  nxt=%s hop=%u %uB",
+                     timebuf, src_str, dst_str,
+                     ipv6_nxt_name(ip6->ip6_nxt),
+                     ip6->ip6_hlim,
+                     ntohs(ip6->ip6_plen));
+        } else {
+            return;
+        }
+
+        detail_ring_push(&g_detail.ring, line);
+        return;
+    }
+
+    /* -L 4 TCP/UDP detail */
+    if (g_cfg->layer_mode == 4) {
+        const struct ip *iph;
+        unsigned int ip_hlen;
+        char src_str[INET_ADDRSTRLEN], dst_str[INET_ADDRSTRLEN];
+        uint16_t sport, dport;
+
+        if (ether_type == ETHERTYPE_IP) {
+            if (header->caplen < sizeof(struct ether_header) + sizeof(struct ip))
+                return;
+            iph = (const struct ip *)(packet + sizeof(struct ether_header));
+            ip_hlen = (unsigned int)iph->ip_hl * 4;
+
+            inet_ntop(AF_INET, &iph->ip_src, src_str, sizeof(src_str));
+            inet_ntop(AF_INET, &iph->ip_dst, dst_str, sizeof(dst_str));
+
+            if (iph->ip_p == IPPROTO_TCP) {
+                if (header->caplen < sizeof(struct ether_header) + ip_hlen + 20)
+                    return;
+                const struct tcphdr *th = (const struct tcphdr *)
+                    (packet + sizeof(struct ether_header) + ip_hlen);
+
+                sport = ntohs(th->th_sport);
+                dport = ntohs(th->th_dport);
+                uint8_t flags = th->th_flags;
+
+                g_detail.l4.tcp_total++;
+                if ((flags & 0x12) == 0x02) g_detail.l4.tcp_syn++;
+                if ((flags & 0x12) == 0x12) g_detail.l4.tcp_synack++;
+                if ((flags & 0x10) && !(flags & 0x02)) g_detail.l4.tcp_ack++;
+                if (flags & 0x01) g_detail.l4.tcp_fin++;
+                if (flags & 0x04) g_detail.l4.tcp_rst++;
+                if (flags & 0x08) g_detail.l4.tcp_psh++;
+
+                char flagbuf[64];
+                tcp_flags_str(flags, flagbuf, sizeof(flagbuf));
+
+                const char *s_svc = port_service_name(sport);
+                const char *d_svc = port_service_name(dport);
+                char src_port_str[32], dst_port_str[32];
+
+                if (s_svc)
+                    snprintf(src_port_str, sizeof(src_port_str),
+                             "%s(%u)", s_svc, sport);
+                else
+                    snprintf(src_port_str, sizeof(src_port_str), "%u", sport);
+
+                if (d_svc)
+                    snprintf(dst_port_str, sizeof(dst_port_str),
+                             "%s(%u)", d_svc, dport);
+                else
+                    snprintf(dst_port_str, sizeof(dst_port_str), "%u", dport);
+
+                snprintf(line, sizeof(line),
+                         "%s  TCP  %s:%s -> %s:%s %s %uB",
+                         timebuf, src_str, src_port_str,
+                         dst_str, dst_port_str,
+                         flagbuf, ntohs(iph->ip_len));
+            } else if (iph->ip_p == IPPROTO_UDP) {
+                if (header->caplen < sizeof(struct ether_header) + ip_hlen + 8)
+                    return;
+                const struct udphdr *uh = (const struct udphdr *)
+                    (packet + sizeof(struct ether_header) + ip_hlen);
+
+                sport = ntohs(uh->uh_sport);
+                dport = ntohs(uh->uh_dport);
+
+                g_detail.l4.udp_total++;
+
+                const char *s_svc = port_service_name(sport);
+                const char *d_svc = port_service_name(dport);
+                char src_port_str[32], dst_port_str[32];
+
+                if (s_svc)
+                    snprintf(src_port_str, sizeof(src_port_str),
+                             "%s(%u)", s_svc, sport);
+                else
+                    snprintf(src_port_str, sizeof(src_port_str), "%u", sport);
+
+                if (d_svc)
+                    snprintf(dst_port_str, sizeof(dst_port_str),
+                             "%s(%u)", d_svc, dport);
+                else
+                    snprintf(dst_port_str, sizeof(dst_port_str), "%u", dport);
+
+                snprintf(line, sizeof(line),
+                         "%s  UDP  %s:%s -> %s:%s %uB",
+                         timebuf, src_str, src_port_str,
+                         dst_str, dst_port_str,
+                         ntohs(iph->ip_len));
+            } else {
+                return;
+            }
+        } else if (ether_type == ETHERTYPE_IPV6) {
+            /* IPv6 TCP/UDP */
+            if (header->caplen < sizeof(struct ether_header) + sizeof(struct ip6_hdr))
+                return;
+            const struct ip6_hdr *ip6 = (const struct ip6_hdr *)
+                (packet + sizeof(struct ether_header));
+            size_t l4_off = sizeof(struct ether_header) + sizeof(struct ip6_hdr);
+
+            char src6[INET6_ADDRSTRLEN], dst6[INET6_ADDRSTRLEN];
+            inet_ntop(AF_INET6, &ip6->ip6_src, src6, sizeof(src6));
+            inet_ntop(AF_INET6, &ip6->ip6_dst, dst6, sizeof(dst6));
+
+            if (ip6->ip6_nxt == IPPROTO_TCP) {
+                if (header->caplen < l4_off + 20) return;
+                const struct tcphdr *th = (const struct tcphdr *)(packet + l4_off);
+                sport = ntohs(th->th_sport);
+                dport = ntohs(th->th_dport);
+                uint8_t flags = th->th_flags;
+
+                g_detail.l4.tcp_total++;
+                if ((flags & 0x12) == 0x02) g_detail.l4.tcp_syn++;
+                if ((flags & 0x12) == 0x12) g_detail.l4.tcp_synack++;
+                if ((flags & 0x10) && !(flags & 0x02)) g_detail.l4.tcp_ack++;
+                if (flags & 0x01) g_detail.l4.tcp_fin++;
+                if (flags & 0x04) g_detail.l4.tcp_rst++;
+                if (flags & 0x08) g_detail.l4.tcp_psh++;
+
+                char flagbuf[64];
+                tcp_flags_str(flags, flagbuf, sizeof(flagbuf));
+
+                snprintf(line, sizeof(line),
+                         "%s  TCP6 %s:%u -> %s:%u %s %uB",
+                         timebuf, src6, sport, dst6, dport,
+                         flagbuf, ntohs(ip6->ip6_plen));
+            } else if (ip6->ip6_nxt == IPPROTO_UDP) {
+                if (header->caplen < l4_off + 8) return;
+                const struct udphdr *uh = (const struct udphdr *)(packet + l4_off);
+                sport = ntohs(uh->uh_sport);
+                dport = ntohs(uh->uh_dport);
+
+                g_detail.l4.udp_total++;
+
+                snprintf(line, sizeof(line),
+                         "%s  UDP6 %s:%u -> %s:%u %uB",
+                         timebuf, src6, sport, dst6, dport,
+                         ntohs(ip6->ip6_plen));
+            } else {
+                return;
+            }
+        } else {
+            return;
+        }
+
+        detail_ring_push(&g_detail.ring, line);
+        return;
+    }
+}
+
 /*
  * SIGINT/SIGTERM handler: clean shutdown.
  */
@@ -204,6 +700,7 @@ static void cleanup_handler(int sig)
 static void cleanup_all(void)
 {
     int i;
+    prometheus_stop();
     for (i = 0; i < iface_count; i++) {
         if (ifaces[i].handle) {
             pcap_close(ifaces[i].handle);
@@ -281,6 +778,140 @@ static void print_text_lines(int *header_count)
                    c->all, c->tcp, c->udp, c->ip, c->ipv6, c->icmp,
                    c->arp, (double)c->bytes * 8.0 / 1024.0);
     }
+}
+
+/*
+ * Print layer detail / resolve mode text output.
+ * Flushes the ring buffer and prints counter summary.
+ */
+static void print_detail_lines(const monitor_config_t *cfg, int *last_count)
+{
+    int i;
+    int count = g_detail.ring.count;
+
+    /* Print new entries since last flush */
+    for (i = *last_count; i < count; i++) {
+        const detail_entry_t *e = detail_ring_get(&g_detail.ring, i);
+        if (e)
+            printf("  %s\n", e->line);
+    }
+    *last_count = count;
+
+    /* When ring wraps, reset tracking */
+    if (count == DETAIL_RING_SIZE && *last_count == DETAIL_RING_SIZE)
+        *last_count = 0;
+
+    (void)cfg;
+}
+
+static void print_detail_summary(const monitor_config_t *cfg)
+{
+    if (cfg->layer_mode == 2) {
+        printf("\n# L2 ARP Summary: Request=%" PRIu32 " Reply=%" PRIu32
+               " Other=%" PRIu32 "\n",
+               g_detail.l2.request, g_detail.l2.reply, g_detail.l2.other);
+    } else if (cfg->layer_mode == 3) {
+        printf("\n# L3 Summary: IPv4=%" PRIu32 " IPv6=%" PRIu32
+               " ICMP=%" PRIu32 "\n",
+               g_detail.l3.ipv4, g_detail.l3.ipv6, g_detail.l3.icmp);
+    } else if (cfg->layer_mode == 4) {
+        printf("\n# L4 Summary: TCP=%" PRIu32 " UDP=%" PRIu32 "\n",
+               g_detail.l4.tcp_total, g_detail.l4.udp_total);
+        printf("#   TCP flags: SYN=%" PRIu32 " SYN/ACK=%" PRIu32
+               " ACK=%" PRIu32 " FIN=%" PRIu32
+               " RST=%" PRIu32 " PSH=%" PRIu32 "\n",
+               g_detail.l4.tcp_syn, g_detail.l4.tcp_synack,
+               g_detail.l4.tcp_ack, g_detail.l4.tcp_fin,
+               g_detail.l4.tcp_rst, g_detail.l4.tcp_psh);
+    } else if (cfg->resolve_mode == 'a') {
+        printf("\n# ARP Resolve Summary: Req=%" PRIu32 " Reply=%" PRIu32
+               " Matched=%" PRIu32 " Timeout=%" PRIu32
+               " Gratuitous=%" PRIu32 "\n",
+               g_detail.arp_res.counter.requests,
+               g_detail.arp_res.counter.replies,
+               g_detail.arp_res.counter.matched,
+               g_detail.arp_res.counter.timeouts,
+               g_detail.arp_res.counter.gratuitous);
+    } else if (cfg->resolve_mode == 'd') {
+        printf("\n# DNS Resolve Summary: Query=%" PRIu32 " Response=%" PRIu32
+               " Matched=%" PRIu32 " Timeout=%" PRIu32
+               " NXDOMAIN=%" PRIu32 " Error=%" PRIu32 "\n",
+               g_detail.dns_res.counter.queries,
+               g_detail.dns_res.counter.responses,
+               g_detail.dns_res.counter.matched,
+               g_detail.dns_res.counter.timeouts,
+               g_detail.dns_res.counter.nxdomain,
+               g_detail.dns_res.counter.errors);
+    }
+}
+
+/*
+ * Layer detail / resolve mode text main loop.
+ */
+static int run_layer_detail(const monitor_config_t *cfg)
+{
+    long long last_tick;
+    long long last_expire;
+    int last_count = 0;
+    int i;
+
+    signal(SIGINT,  cleanup_handler);
+    signal(SIGTERM, cleanup_handler);
+
+    memset(&g_detail, 0, sizeof(g_detail));
+
+    if (cfg->layer_mode)
+        printf("# Layer %d detail mode\n", cfg->layer_mode);
+    else if (cfg->resolve_mode == 'a')
+        printf("# ARP resolve mode (-R arp)\n");
+    else if (cfg->resolve_mode == 'd')
+        printf("# DNS resolve mode (-R dns)\n");
+
+    last_tick = now_ms();
+    last_expire = last_tick;
+
+    while (running) {
+        for (i = 0; i < iface_count; i++) {
+            int ret = pcap_dispatch(ifaces[i].handle, -1, packet_handler,
+                                    (u_char *)&ifaces[i].pkt_cnt);
+            if (ret == PCAP_ERROR) {
+                fprintf(stderr, "pcap error on %s: %s\n",
+                        ifaces[i].name, pcap_geterr(ifaces[i].handle));
+                running = 0;
+                break;
+            }
+        }
+
+        /* Flush display at interval */
+        if (now_ms() - last_tick >= (long long)cfg->interval_ms) {
+            last_tick += cfg->interval_ms;
+            print_detail_lines(cfg, &last_count);
+
+            for (i = 0; i < iface_count; i++) {
+                accumulate_totals(&ifaces[i]);
+                memset(&ifaces[i].pkt_cnt, 0, sizeof(packet_counter_t));
+            }
+
+            if (cfg->duration > 0 && ifaces[0].elapsed_sec >= cfg->duration)
+                break;
+        }
+
+        /* Expire pending resolve entries every second */
+        if (now_ms() - last_expire >= 1000) {
+            last_expire = now_ms();
+            struct timeval now_tv;
+            gettimeofday(&now_tv, NULL);
+            if (cfg->resolve_mode == 'a')
+                arp_resolver_expire(&g_detail.arp_res, &now_tv);
+            else if (cfg->resolve_mode == 'd')
+                dns_resolver_expire(&g_detail.dns_res, &now_tv);
+        }
+    }
+
+    printf("\n# Capture stopped.\n");
+    print_detail_summary(cfg);
+
+    return 0;
 }
 
 /*
@@ -410,6 +1041,91 @@ static void print_summary(void)
 
 #ifdef HAS_NCURSES
 /*
+ * TUI mode for layer detail / resolve mode.
+ */
+static int run_tui_detail(const monitor_config_t *cfg)
+{
+    int paused = 0;
+    long long last_tick, last_expire;
+    int action, i;
+
+    if (tui_init(cfg) < 0)
+        return 1;
+
+    signal(SIGALRM, SIG_IGN);
+    signal(SIGINT,  cleanup_handler);
+    signal(SIGTERM, cleanup_handler);
+
+    memset(&g_detail, 0, sizeof(g_detail));
+
+    tui_update_detail(&g_detail, 0, paused, cfg);
+
+    last_tick = now_ms();
+    last_expire = last_tick;
+
+    for (;;) {
+        if (!running)
+            break;
+
+        for (i = 0; i < iface_count; i++) {
+            int ret = pcap_dispatch(ifaces[i].handle, -1, packet_handler,
+                                    (u_char *)&ifaces[i].pkt_cnt);
+            if (ret == PCAP_ERROR_BREAK) {
+                tui_cleanup();
+                return 0;
+            }
+        }
+
+        if (now_ms() - last_tick >= (long long)cfg->interval_ms) {
+            last_tick += cfg->interval_ms;
+            if (!paused) {
+                for (i = 0; i < iface_count; i++)
+                    accumulate_totals(&ifaces[i]);
+
+                tui_update_detail(&g_detail, ifaces[0].elapsed_sec,
+                                  paused, cfg);
+
+                for (i = 0; i < iface_count; i++)
+                    memset(&ifaces[i].pkt_cnt, 0, sizeof(packet_counter_t));
+
+                if (cfg->duration > 0 &&
+                    ifaces[0].elapsed_sec >= cfg->duration)
+                    break;
+            }
+        }
+
+        /* Expire pending resolve entries */
+        if (now_ms() - last_expire >= 1000) {
+            last_expire = now_ms();
+            struct timeval now_tv;
+            gettimeofday(&now_tv, NULL);
+            if (cfg->resolve_mode == 'a')
+                arp_resolver_expire(&g_detail.arp_res, &now_tv);
+            else if (cfg->resolve_mode == 'd')
+                dns_resolver_expire(&g_detail.dns_res, &now_tv);
+        }
+
+        action = tui_handle_input();
+        if (action == 'q')
+            break;
+        if (action == 'p')
+            paused = !paused;
+        if (action == 'r') {
+            memset(&g_detail, 0, sizeof(g_detail));
+            for (i = 0; i < iface_count; i++) {
+                memset(&ifaces[i].pkt_cnt, 0, sizeof(packet_counter_t));
+                memset(&ifaces[i].total_cnt, 0, sizeof(packet_counter_t));
+                ifaces[i].elapsed_sec = 0;
+            }
+            tui_update_detail(&g_detail, 0, paused, cfg);
+        }
+    }
+
+    tui_cleanup();
+    return 0;
+}
+
+/*
  * TUI mode main loop using round-robin pcap_dispatch (non-blocking).
  */
 static int run_tui(const monitor_config_t *cfg)
@@ -511,7 +1227,7 @@ static int run_tui(const monitor_config_t *cfg)
 static void usage(const char *prog)
 {
     fprintf(stderr,
-            "Usage: %s [-d device [-d device2 ...]] [-i|-o] [-f filter] [-L 2|3|4]\n"
+            "Usage: %s [-d device [-d device2 ...]] [-i|-o] [-f filter] [-L 2|3|4] [-R arp|dns]\n"
             "       %s [-r file] [-w file] [-u] [-j|-c] [-t secs] [-l logfile] [-a kbps] [-T N] [-h]\n"
             "\n"
             "  -d device   Network interface (repeatable, max %d)\n"
@@ -519,6 +1235,7 @@ static void usage(const char *prog)
             "  -o          Capture outgoing packets only\n"
             "  -f filter   BPF filter expression (tcpdump syntax)\n"
             "  -L 2|3|4    Layer detail mode (2=ARP, 3=IP/ICMP, 4=TCP/UDP)\n"
+            "  -R arp|dns  Name resolution visualization mode\n"
             "  -r file     Read packets from pcap file (offline mode)\n"
             "  -w file     Write captured packets to pcap file\n"
 #ifdef HAS_NCURSES
@@ -534,6 +1251,7 @@ static void usage(const char *prog)
             "  -l logfile  Write stats to log file\n"
             "  -a kbps     Alert when bandwidth exceeds threshold\n"
             "  -T N        Show top N hosts/ports at exit\n"
+            "  --prometheus :PORT  Expose Prometheus metrics on HTTP port\n"
             "  -h          Show this help\n",
             prog, prog, MAX_IFACES);
 }
@@ -549,8 +1267,29 @@ int main(int argc, char *argv[])
     memset(&cfg, 0, sizeof(cfg));
     cfg.interval_ms = 1000;
 
-    while ((opt = getopt(argc, argv, "d:iof:r:w:jt:l:L:ca:T:upn:h")) != -1) {
+    static struct option long_opts[] = {
+        { "prometheus", required_argument, NULL, 0 },
+        { NULL, 0, NULL, 0 }
+    };
+    int long_idx = 0;
+
+    while ((opt = getopt_long(argc, argv, "d:iof:r:w:jt:l:L:R:ca:T:upn:h",
+                              long_opts, &long_idx)) != -1) {
         switch (opt) {
+        case 0:
+            /* Long options */
+            if (strcmp(long_opts[long_idx].name, "prometheus") == 0) {
+                const char *arg = optarg;
+                /* Accept ":PORT" or "PORT" */
+                if (arg[0] == ':') arg++;
+                cfg.prometheus_port = atoi(arg);
+                if (cfg.prometheus_port < 1 || cfg.prometheus_port > 65535) {
+                    fprintf(stderr,
+                            "Error: --prometheus requires port 1-65535\n");
+                    return 1;
+                }
+            }
+            break;
         case 'd':
             if (iface_count >= MAX_IFACES) {
                 fprintf(stderr, "Error: max %d interfaces\n", MAX_IFACES);
@@ -610,6 +1349,16 @@ int main(int argc, char *argv[])
                 return 1;
             }
             break;
+        case 'R':
+            if (strcmp(optarg, "arp") == 0)
+                cfg.resolve_mode = 'a';
+            else if (strcmp(optarg, "dns") == 0)
+                cfg.resolve_mode = 'd';
+            else {
+                fprintf(stderr, "Error: -R requires 'arp' or 'dns'\n");
+                return 1;
+            }
+            break;
         case 'u':
             cfg.use_tui = 1;
             break;
@@ -634,8 +1383,12 @@ int main(int argc, char *argv[])
     }
 
     /* Validate mutually exclusive options */
-    if (cfg.layer_mode && (cfg.json_mode || cfg.csv_mode)) {
-        fprintf(stderr, "Error: -L cannot be combined with -j or -c\n");
+    if (cfg.layer_mode && cfg.resolve_mode) {
+        fprintf(stderr, "Error: -L and -R are mutually exclusive\n");
+        return 1;
+    }
+    if ((cfg.layer_mode || cfg.resolve_mode) && (cfg.json_mode || cfg.csv_mode)) {
+        fprintf(stderr, "Error: -L/-R cannot be combined with -j or -c\n");
         return 1;
     }
     if (cfg.use_tui && (cfg.json_mode || cfg.csv_mode)) {
@@ -654,6 +1407,9 @@ int main(int argc, char *argv[])
         fprintf(stderr, "Error: -r cannot be combined with -u\n");
         return 1;
     }
+
+    /* Set g_cfg for detail_packet_handler access */
+    g_cfg = &cfg;
 
     if (cfg.read_file) {
         /* -r mode: open pcap file for offline reading */
@@ -674,6 +1430,12 @@ int main(int argc, char *argv[])
                     layer_fbuf, sizeof(layer_fbuf));
                 if (lf)
                     effective_filter = lf;
+            } else if (cfg.resolve_mode) {
+                const char *rf = resolve_build_filter(
+                    cfg.resolve_mode, cfg.filter_expr,
+                    layer_fbuf, sizeof(layer_fbuf));
+                if (rf)
+                    effective_filter = rf;
             }
 
             if (effective_filter) {
@@ -755,7 +1517,7 @@ int main(int argc, char *argv[])
                             ifaces[i].name, pcap_geterr(ifaces[i].handle));
             }
 
-            /* Apply BPF filter (layer mode auto-filter + user filter) */
+            /* Apply BPF filter (layer/resolve mode auto-filter + user filter) */
             {
                 char layer_fbuf[512];
                 const char *effective_filter = cfg.filter_expr;
@@ -766,6 +1528,12 @@ int main(int argc, char *argv[])
                         layer_fbuf, sizeof(layer_fbuf));
                     if (lf)
                         effective_filter = lf;
+                } else if (cfg.resolve_mode) {
+                    const char *rf = resolve_build_filter(
+                        cfg.resolve_mode, cfg.filter_expr,
+                        layer_fbuf, sizeof(layer_fbuf));
+                    if (rf)
+                        effective_filter = rf;
                 }
 
                 if (effective_filter) {
@@ -790,6 +1558,16 @@ int main(int argc, char *argv[])
     }
 
     dir_str = cfg.direction == 0 ? "both" : cfg.direction == 1 ? "in" : "out";
+
+    /* Start Prometheus exporter if requested */
+    if (cfg.prometheus_port > 0) {
+        if (prometheus_start(cfg.prometheus_port, ifaces, iface_count) < 0) {
+            fprintf(stderr, "Warning: failed to start Prometheus exporter\n");
+        } else {
+            fprintf(stderr, "# Prometheus metrics: http://localhost:%d/metrics\n",
+                    cfg.prometheus_port);
+        }
+    }
 
     /* Initialize Top-N tracking if requested */
     if (cfg.top_n > 0) {
@@ -821,7 +1599,11 @@ int main(int argc, char *argv[])
 
 #ifdef HAS_NCURSES
     if (cfg.use_tui) {
-        int ret = run_tui(&cfg);
+        int ret;
+        if (cfg.layer_mode || cfg.resolve_mode)
+            ret = run_tui_detail(&cfg);
+        else
+            ret = run_tui(&cfg);
         if (g_dumper) {
             pcap_dump_close(g_dumper);
             g_dumper = NULL;
@@ -849,6 +1631,10 @@ int main(int argc, char *argv[])
     }
     if (cfg.layer_mode)
         printf(" [L%d detail]", cfg.layer_mode);
+    if (cfg.resolve_mode == 'a')
+        printf(" [resolve: ARP]");
+    else if (cfg.resolve_mode == 'd')
+        printf(" [resolve: DNS]");
     if (cfg.filter_expr)
         printf(" [filter: %s]", cfg.filter_expr);
     if (cfg.no_promisc)
@@ -858,13 +1644,18 @@ int main(int argc, char *argv[])
     printf("\n");
 
     {
-        int ret = run_text(&cfg);
+        int ret;
+        if (cfg.layer_mode || cfg.resolve_mode)
+            ret = run_layer_detail(&cfg);
+        else
+            ret = run_text(&cfg);
         if (g_dumper) {
             pcap_dump_close(g_dumper);
             g_dumper = NULL;
         }
         cleanup_all();
-        if (ret == 0 && !cfg.json_mode && !cfg.csv_mode)
+        if (ret == 0 && !cfg.json_mode && !cfg.csv_mode &&
+            !cfg.layer_mode && !cfg.resolve_mode)
             print_summary();
         if (ret == 0 && g_flow_stats)
             flow_stats_print(g_flow_stats, cfg.top_n);

--- a/pkt_monitor.h
+++ b/pkt_monitor.h
@@ -47,7 +47,15 @@ typedef struct {
     const char *write_file;     /* -w: pcap output file */
     const char *read_file;      /* -r: pcap input file */
     int         layer_mode;     /* -L: 0=all, 2/3/4=layer detail */
+    int         resolve_mode;   /* -R: 0=none, 'a'=arp, 'd'=dns */
+    int         prometheus_port; /* --prometheus: 0=disabled */
 } monitor_config_t;
+
+/*
+ * Look up well-known port service name.
+ * Returns NULL if port is not in the table.
+ */
+const char *port_service_name(uint16_t port);
 
 static inline void get_time_str(char *buf, size_t len)
 {

--- a/prometheus.c
+++ b/prometheus.c
@@ -1,0 +1,268 @@
+/*
+ * prometheus.c - Prometheus metrics exporter
+ *
+ * Minimal HTTP server on a background thread.
+ * Serves /metrics in Prometheus text exposition format.
+ * No external library dependencies.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <inttypes.h>
+#include <errno.h>
+#include <pthread.h>
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include "prometheus.h"
+
+static int server_fd = -1;
+static pthread_t server_thread;
+static volatile int server_running;
+
+/* Shared state (read-only from server thread) */
+static iface_ctx_t *prom_ifaces;
+static int prom_iface_count;
+
+/*
+ * Build the metrics body.
+ * Uses cumulative total_cnt (never reset) per Prometheus counter convention.
+ */
+static int build_metrics(char *buf, size_t buflen)
+{
+    int i;
+    size_t off = 0;
+    uint64_t total_bytes = 0;
+    uint32_t total_all = 0, total_ip = 0, total_ipv6 = 0;
+    uint32_t total_arp = 0, total_icmp = 0, total_tcp = 0, total_udp = 0;
+
+    /* Aggregate across interfaces */
+    for (i = 0; i < prom_iface_count; i++) {
+        const packet_counter_t *t = &prom_ifaces[i].total_cnt;
+        total_all   += t->all;
+        total_ip    += t->ip;
+        total_ipv6  += t->ipv6;
+        total_arp   += t->arp;
+        total_icmp  += t->icmp;
+        total_tcp   += t->tcp;
+        total_udp   += t->udp;
+        total_bytes += t->bytes;
+    }
+
+    off += (size_t)snprintf(buf + off, buflen - off,
+        "# HELP pkt_monitor_packets_total Total packets captured\n"
+        "# TYPE pkt_monitor_packets_total counter\n"
+        "pkt_monitor_packets_total{protocol=\"all\"} %" PRIu32 "\n"
+        "pkt_monitor_packets_total{protocol=\"ipv4\"} %" PRIu32 "\n"
+        "pkt_monitor_packets_total{protocol=\"ipv6\"} %" PRIu32 "\n"
+        "pkt_monitor_packets_total{protocol=\"arp\"} %" PRIu32 "\n"
+        "pkt_monitor_packets_total{protocol=\"icmp\"} %" PRIu32 "\n"
+        "pkt_monitor_packets_total{protocol=\"tcp\"} %" PRIu32 "\n"
+        "pkt_monitor_packets_total{protocol=\"udp\"} %" PRIu32 "\n",
+        total_all, total_ip, total_ipv6, total_arp,
+        total_icmp, total_tcp, total_udp);
+
+    off += (size_t)snprintf(buf + off, buflen - off,
+        "# HELP pkt_monitor_bytes_total Total bytes captured\n"
+        "# TYPE pkt_monitor_bytes_total counter\n"
+        "pkt_monitor_bytes_total %" PRIu64 "\n",
+        total_bytes);
+
+    /* Per-interface metrics */
+    if (prom_iface_count > 1) {
+        off += (size_t)snprintf(buf + off, buflen - off,
+            "# HELP pkt_monitor_iface_packets_total "
+            "Total packets per interface\n"
+            "# TYPE pkt_monitor_iface_packets_total counter\n");
+
+        for (i = 0; i < prom_iface_count; i++) {
+            const packet_counter_t *t = &prom_ifaces[i].total_cnt;
+            off += (size_t)snprintf(buf + off, buflen - off,
+                "pkt_monitor_iface_packets_total"
+                "{iface=\"%s\",protocol=\"all\"} %" PRIu32 "\n"
+                "pkt_monitor_iface_packets_total"
+                "{iface=\"%s\",protocol=\"tcp\"} %" PRIu32 "\n"
+                "pkt_monitor_iface_packets_total"
+                "{iface=\"%s\",protocol=\"udp\"} %" PRIu32 "\n",
+                prom_ifaces[i].name, t->all,
+                prom_ifaces[i].name, t->tcp,
+                prom_ifaces[i].name, t->udp);
+        }
+
+        off += (size_t)snprintf(buf + off, buflen - off,
+            "# HELP pkt_monitor_iface_bytes_total "
+            "Total bytes per interface\n"
+            "# TYPE pkt_monitor_iface_bytes_total counter\n");
+
+        for (i = 0; i < prom_iface_count; i++) {
+            off += (size_t)snprintf(buf + off, buflen - off,
+                "pkt_monitor_iface_bytes_total"
+                "{iface=\"%s\"} %" PRIu64 "\n",
+                prom_ifaces[i].name,
+                prom_ifaces[i].total_cnt.bytes);
+        }
+    }
+
+    /* Uptime */
+    off += (size_t)snprintf(buf + off, buflen - off,
+        "# HELP pkt_monitor_uptime_seconds Capture duration\n"
+        "# TYPE pkt_monitor_uptime_seconds gauge\n"
+        "pkt_monitor_uptime_seconds %d\n",
+        prom_ifaces[0].elapsed_sec);
+
+    return (int)off;
+}
+
+/*
+ * Handle a single HTTP connection.
+ */
+static void handle_client(int client_fd)
+{
+    char req[1024];
+    char body[8192];
+    char response[8192 + 256];
+    ssize_t n;
+    int body_len;
+
+    n = read(client_fd, req, sizeof(req) - 1);
+    if (n <= 0) {
+        close(client_fd);
+        return;
+    }
+    req[n] = '\0';
+
+    /* Only serve GET /metrics */
+    if (strncmp(req, "GET /metrics", 12) == 0) {
+        body_len = build_metrics(body, sizeof(body));
+        snprintf(response, sizeof(response),
+                 "HTTP/1.1 200 OK\r\n"
+                 "Content-Type: text/plain; version=0.0.4; charset=utf-8\r\n"
+                 "Content-Length: %d\r\n"
+                 "Connection: close\r\n"
+                 "\r\n"
+                 "%s",
+                 body_len, body);
+    } else if (strncmp(req, "GET / ", 6) == 0 ||
+               strncmp(req, "GET /\r", 6) == 0) {
+        const char *html =
+            "<html><body><h1>pkt_monitor</h1>"
+            "<p><a href=\"/metrics\">/metrics</a></p>"
+            "</body></html>";
+        int html_len = (int)strlen(html);
+        snprintf(response, sizeof(response),
+                 "HTTP/1.1 200 OK\r\n"
+                 "Content-Type: text/html\r\n"
+                 "Content-Length: %d\r\n"
+                 "Connection: close\r\n"
+                 "\r\n"
+                 "%s",
+                 html_len, html);
+    } else {
+        const char *not_found = "404 Not Found\n";
+        int nf_len = (int)strlen(not_found);
+        snprintf(response, sizeof(response),
+                 "HTTP/1.1 404 Not Found\r\n"
+                 "Content-Type: text/plain\r\n"
+                 "Content-Length: %d\r\n"
+                 "Connection: close\r\n"
+                 "\r\n"
+                 "%s",
+                 nf_len, not_found);
+    }
+
+    /* Write full response (ignore partial write for simplicity) */
+    (void)write(client_fd, response, strlen(response));
+    close(client_fd);
+}
+
+/*
+ * Server thread main loop.
+ */
+static void *server_loop(void *arg)
+{
+    (void)arg;
+
+    while (server_running) {
+        struct sockaddr_in cli_addr;
+        socklen_t cli_len = sizeof(cli_addr);
+        int client_fd;
+
+        client_fd = accept(server_fd, (struct sockaddr *)&cli_addr, &cli_len);
+        if (client_fd < 0) {
+            if (!server_running) break;
+            continue;
+        }
+
+        /* Set a short read timeout so we don't block forever */
+        struct timeval tv = { .tv_sec = 2, .tv_usec = 0 };
+        setsockopt(client_fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+        handle_client(client_fd);
+    }
+
+    return NULL;
+}
+
+int prometheus_start(int port, iface_ctx_t *ifaces, int iface_count)
+{
+    struct sockaddr_in addr;
+    int opt = 1;
+
+    prom_ifaces = ifaces;
+    prom_iface_count = iface_count;
+
+    server_fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (server_fd < 0) {
+        perror("prometheus: socket");
+        return -1;
+    }
+
+    setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = INADDR_ANY;
+    addr.sin_port = htons((uint16_t)port);
+
+    if (bind(server_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        perror("prometheus: bind");
+        close(server_fd);
+        server_fd = -1;
+        return -1;
+    }
+
+    if (listen(server_fd, 5) < 0) {
+        perror("prometheus: listen");
+        close(server_fd);
+        server_fd = -1;
+        return -1;
+    }
+
+    server_running = 1;
+
+    if (pthread_create(&server_thread, NULL, server_loop, NULL) != 0) {
+        perror("prometheus: pthread_create");
+        close(server_fd);
+        server_fd = -1;
+        return -1;
+    }
+
+    /* Detach so cleanup is simpler */
+    pthread_detach(server_thread);
+
+    return 0;
+}
+
+void prometheus_stop(void)
+{
+    if (server_fd < 0) return;
+
+    server_running = 0;
+    /* Close server socket to unblock accept() */
+    close(server_fd);
+    server_fd = -1;
+}

--- a/prometheus.h
+++ b/prometheus.h
@@ -1,0 +1,23 @@
+/*
+ * prometheus.h - Prometheus metrics exporter (simple HTTP server)
+ */
+
+#ifndef PROMETHEUS_H
+#define PROMETHEUS_H
+
+#include "pkt_monitor.h"
+
+/*
+ * Start the Prometheus metrics HTTP server on the given port.
+ * Spawns a background thread to handle requests.
+ * ifaces/iface_count are read by the metrics handler (read-only).
+ * Returns 0 on success, -1 on error.
+ */
+int prometheus_start(int port, iface_ctx_t *ifaces, int iface_count);
+
+/*
+ * Stop the Prometheus server and clean up.
+ */
+void prometheus_stop(void);
+
+#endif /* PROMETHEUS_H */

--- a/stats.c
+++ b/stats.c
@@ -9,6 +9,7 @@
 #include <arpa/inet.h>
 
 #include "stats.h"
+#include "pkt_monitor.h"
 
 /* ---- well-known port names -------------------------------------------- */
 
@@ -29,7 +30,7 @@ static const port_name_t well_known[] = {
     { 0, NULL }
 };
 
-static const char *port_service_name(uint16_t port)
+const char *port_service_name(uint16_t port)
 {
     const port_name_t *p;
     for (p = well_known; p->name; p++)

--- a/tui.c
+++ b/tui.c
@@ -354,6 +354,157 @@ void tui_update(iface_ctx_t *ifaces, int iface_count,
     refresh();
 }
 
+/*
+ * Draw layer detail counters in the upper area.
+ * Returns the next available row.
+ */
+static int draw_detail_counters(int start_row, const detail_ctx_t *ctx,
+                                const monitor_config_t *cfg)
+{
+    int row = start_row;
+
+    if (cfg->layer_mode == 2) {
+        attron(A_BOLD);
+        mvprintw(row, 2, "ARP Counters:");
+        attroff(A_BOLD);
+        row++;
+        mvprintw(row, 4, "Request: %7" PRIu32 "  Reply: %7" PRIu32
+                 "  Other: %7" PRIu32,
+                 ctx->l2.request, ctx->l2.reply, ctx->l2.other);
+        row++;
+    } else if (cfg->layer_mode == 3) {
+        attron(A_BOLD);
+        mvprintw(row, 2, "IP/ICMP Counters:");
+        attroff(A_BOLD);
+        row++;
+        mvprintw(row, 4, "IPv4: %7" PRIu32 "  IPv6: %7" PRIu32
+                 "  ICMP: %7" PRIu32,
+                 ctx->l3.ipv4, ctx->l3.ipv6, ctx->l3.icmp);
+        row++;
+    } else if (cfg->layer_mode == 4) {
+        attron(A_BOLD);
+        mvprintw(row, 2, "TCP/UDP Counters:");
+        attroff(A_BOLD);
+        row++;
+        mvprintw(row, 4, "TCP: %7" PRIu32 "  UDP: %7" PRIu32,
+                 ctx->l4.tcp_total, ctx->l4.udp_total);
+        row++;
+        attron(A_DIM);
+        mvprintw(row, 4, "SYN:%u S/A:%u ACK:%u FIN:%u RST:%u PSH:%u",
+                 ctx->l4.tcp_syn, ctx->l4.tcp_synack,
+                 ctx->l4.tcp_ack, ctx->l4.tcp_fin,
+                 ctx->l4.tcp_rst, ctx->l4.tcp_psh);
+        attroff(A_DIM);
+        row++;
+    } else if (cfg->resolve_mode == 'a') {
+        attron(A_BOLD);
+        mvprintw(row, 2, "ARP Resolve:");
+        attroff(A_BOLD);
+        row++;
+        mvprintw(row, 4, "Req: %u  Reply: %u  Matched: %u  Timeout: %u  Grat: %u",
+                 ctx->arp_res.counter.requests,
+                 ctx->arp_res.counter.replies,
+                 ctx->arp_res.counter.matched,
+                 ctx->arp_res.counter.timeouts,
+                 ctx->arp_res.counter.gratuitous);
+        row++;
+    } else if (cfg->resolve_mode == 'd') {
+        attron(A_BOLD);
+        mvprintw(row, 2, "DNS Resolve:");
+        attroff(A_BOLD);
+        row++;
+        mvprintw(row, 4, "Q: %u  R: %u  Match: %u  Timeout: %u  NX: %u  Err: %u",
+                 ctx->dns_res.counter.queries,
+                 ctx->dns_res.counter.responses,
+                 ctx->dns_res.counter.matched,
+                 ctx->dns_res.counter.timeouts,
+                 ctx->dns_res.counter.nxdomain,
+                 ctx->dns_res.counter.errors);
+        row++;
+    }
+
+    /* Separator */
+    mvhline(row, 1, ACS_HLINE, COLS - 2);
+    row++;
+
+    return row;
+}
+
+/*
+ * Draw ring buffer entries in the lower area.
+ */
+static void draw_ring_buffer(int start_row, int max_rows,
+                             const detail_ring_t *ring)
+{
+    int i, row;
+    int show_count;
+
+    show_count = ring->count;
+    if (show_count > max_rows)
+        show_count = max_rows;
+
+    /* Show most recent entries (from bottom) */
+    int offset = ring->count - show_count;
+
+    for (i = 0; i < show_count; i++) {
+        const detail_entry_t *e = detail_ring_get(ring, offset + i);
+        row = start_row + i;
+        if (row >= LINES - 2) break;
+        if (e) {
+            attron(COLOR_PAIR(4));
+            mvprintw(row, 2, "%-*.*s", COLS - 4, COLS - 4, e->line);
+            attroff(COLOR_PAIR(4));
+        }
+    }
+}
+
+void tui_update_detail(const detail_ctx_t *ctx, int elapsed_sec,
+                       int paused, const monitor_config_t *cfg)
+{
+    int row;
+    char title[64];
+
+    if (needs_resize) {
+        needs_resize = 0;
+        endwin();
+        refresh();
+    }
+
+    erase();
+
+    /* Build title */
+    if (cfg->layer_mode)
+        snprintf(title, sizeof(title), "L%d detail", cfg->layer_mode);
+    else if (cfg->resolve_mode == 'a')
+        snprintf(title, sizeof(title), "ARP resolve");
+    else if (cfg->resolve_mode == 'd')
+        snprintf(title, sizeof(title), "DNS resolve");
+    else
+        snprintf(title, sizeof(title), "detail");
+
+    row = draw_header(title, elapsed_sec, paused, cfg);
+
+    /* Draw counters */
+    row = draw_detail_counters(row, ctx, cfg);
+    row++;
+
+    /* Draw ring buffer (fill remaining space) */
+    {
+        int max_rows = LINES - row - 3;
+        if (max_rows > 0)
+            draw_ring_buffer(row, max_rows, &ctx->ring);
+    }
+
+    /* Footer */
+    row = LINES - 2;
+    mvhline(row - 1, 1, ACS_HLINE, COLS - 2);
+    attron(A_DIM);
+    mvprintw(row, 2, "[q] Quit  [p] Pause  [r] Reset counters");
+    attroff(A_DIM);
+
+    refresh();
+}
+
 int tui_handle_input(void)
 {
     int ch = getch();

--- a/tui.h
+++ b/tui.h
@@ -6,11 +6,16 @@
 #define TUI_H
 
 #include "pkt_monitor.h"
+#include "layer_detail.h"
 
 int  tui_init(const monitor_config_t *cfg);
 void tui_update(iface_ctx_t *ifaces, int iface_count,
                 int paused, const monitor_config_t *cfg);
 void tui_cleanup(void);
 int  tui_handle_input(void);  /* returns: 0=continue, 'q'=quit, 'p'=pause, 'r'=reset */
+
+/* Layer detail / resolve mode TUI update */
+void tui_update_detail(const detail_ctx_t *ctx, int elapsed_sec,
+                       int paused, const monitor_config_t *cfg);
 
 #endif /* TUI_H */


### PR DESCRIPTION
## Summary

- **-L 2**: ARP パケット詳細表示（REQ/REPLY/opcode・MACアドレス・L2カウンタ）
- **-L 3**: IPv4/IPv6/ICMP 詳細表示（TTL・プロトコル名・ICMPタイプ名・L3カウンタ）
- **-L 4**: TCP/UDP 詳細表示（フラグデコード[SYN,ACK,...]・Well-knownポート名・IPv6対応・L4カウンタ）
- **-R arp**: ARP 名前解決可視化（Request→Reply ペアマッチ・応答時間ms・Gratuitous ARP検出・3秒タイムアウト）
- **-R dns**: DNS 名前解決可視化（txidマッチング・A/AAAA/CNAME/MX/PTRパーサー・RCODE表示・5秒タイムアウト）
- **--prometheus :PORT**: Prometheus メトリクス HTTP サーバー（バックグラウンドスレッド・/metricsエンドポイント・外部ライブラリ不要）
- 全新モードでテキスト出力・TUI(-u)表示の両方対応
- 新規ファイル: `dns_parse.c/h`（圧縮ポインタ対応DNSパーサー）、`prometheus.c/h`（ソケット直書きHTTPサーバー）

Closes #22, #23, #24, #25, #26, #17, #13

## Test plan

- [ ] `make clean && make` で警告ゼロ確認
- [ ] `sudo ./pkt_monitor -L 2` で ARP 詳細表示（`arping` で検証）
- [ ] `sudo ./pkt_monitor -L 3` で IP/ICMP 詳細表示（`ping` で検証）
- [ ] `sudo ./pkt_monitor -L 4` で TCP/UDP 詳細表示（`curl` で検証）
- [ ] `sudo ./pkt_monitor -R arp` で ARP 解決時間表示
- [ ] `sudo ./pkt_monitor -R dns` で DNS 解決時間・レコード表示
- [ ] `sudo ./pkt_monitor --prometheus :9090` 起動後 `curl localhost:9090/metrics` でメトリクス確認
- [ ] TUI モード: `sudo ./pkt_monitor -L 4 -u` / `sudo ./pkt_monitor -R dns -u`
- [ ] 排他オプション: `-L 2 -R arp` がエラーになること

🤖 Generated with [Claude Code](https://claude.com/claude-code)